### PR TITLE
feat(hulista): method combinations, sealed glue, bump 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.1 - 2026-04-05
+
+### Added
+
+- `fp-combinators`: `async_sequence`, `async_traverse`, and `async_traverse_all` — sequential async Result helpers for ordered validation chains and async batch processing.
+- `taskgroup-collect`: `collect_results()` convenience wrapper for concurrent fan-out, plus `outcome_to_result()`, `result_to_outcome()`, and `outcomes_to_results()` TaskOutcome↔Result adapters bridging taskgroup-collect and fp-combinators.
+- `persistent-collections`: `freeze()` and `thaw()` recursive converters between plain Python dicts/lists and PersistentMap/PersistentVector, enabling gradual migration of mutable data structures.
+- `live-dispatch`: CLOS-inspired method combinations (`:before`, `:after`, `:around`) with traced execution support, plus strengthened sealed-type exhaustiveness verification with per-parameter and auto-discovery modes.
+- `sealed-typing`: `verify_dispatch_exhaustive()` convenience function for verifying live-dispatch handler coverage of sealed hierarchies.
+
 ## 0.1.0 - 2026-04-05
 
 Initial monorepo release for the hulista package family.

--- a/asyncio-actors/pyproject.toml
+++ b/asyncio-actors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asyncio-actors"
-version = "0.1.0"
+version = "0.1.1"
 description = "OTP-inspired actor primitives for Python's asyncio with supervision trees, bounded inboxes, and async-sync bridge"
 readme = "README.md"
 license = "MIT"

--- a/fp-combinators/pyproject.toml
+++ b/fp-combinators/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-combinators"
-version = "0.1.0"
+version = "0.1.1"
 description = "Lightweight functional programming combinators: pipe, compose, first_some"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hulista"
-version = "0.1.0"
+version = "0.1.1"
 description = "Functional, immutable, concurrent Python — all batteries included"
 readme = "README.md"
 license = "MIT"

--- a/live-dispatch/README.md
+++ b/live-dispatch/README.md
@@ -95,6 +95,58 @@ with versioned(dispatch) as v:
 assert dispatch("test") == "v1"
 ```
 
+### Method combinations (CLOS-inspired)
+
+```python
+from live_dispatch import Dispatcher
+
+dispatch = Dispatcher("process")
+
+class Task:
+    def __init__(self, name: str):
+        self.name = name
+
+@dispatch.register
+def handle(task: Task) -> str:
+    return f"done:{task.name}"
+
+@dispatch.before(Task)
+def log_start(task: Task) -> None:
+    print(f"Starting: {task.name}")
+
+@dispatch.after(Task)
+def log_end(task: Task) -> None:
+    print(f"Done: {task.name}")
+
+@dispatch.around(Task)
+def time_it(proceed, task: Task) -> str:
+    import time
+    t0 = time.time()
+    result = proceed(task)
+    print(f"Took {time.time() - t0:.3f}s")
+    return result
+
+dispatch(Task("build"))
+# Prints: Starting: build → runs handle → Prints: Done: build
+# time_it wraps the entire chain
+```
+
+Execution order: `:before` advisors run first (registration order), then the
+primary handler, then `:after` advisors (reverse registration order). `:around`
+advisors wrap the entire chain via a `proceed()` callback. When no advisors
+match, dispatch takes the fast path with zero overhead.
+
+### Traced execution
+
+```python
+result, trace = dispatch.call_traced(Task("deploy"))
+for entry in trace:
+    print(f"  {entry.phase}: {entry.name} ({entry.duration_ms:.1f}ms)")
+```
+
+`call_traced` and `call_async_traced` return `(result, list[CombinationTraceEntry])`
+where each entry records `phase`, `name`, `duration_ms`, and `type_key`.
+
 ### Sealed type exhaustiveness checking
 
 ```python
@@ -115,6 +167,12 @@ def on_click(e: Click): ...
 
 # Raises TypeError listing missing: {Hover}
 dispatch.verify_exhaustive(Event)
+
+# Per-parameter checking
+dispatch.verify_exhaustive(Event, param="e")
+
+# Auto-discover all sealed types and verify each
+dispatch.verify_all_sealed()
 ```
 
 ## API reference
@@ -125,12 +183,23 @@ dispatch.verify_exhaustive(Event)
 |---|---|---|
 | `.register(func, *, priority=0)` | `(Callable) -> Callable` | Register handler (decorator or direct call) |
 | `.fallback(func)` | `(Callable) -> Callable` | Register fallback for unmatched calls |
-| `.unregister(func)` | `(Callable) -> None` | Remove a handler |
-| `.clear()` | `() -> None` | Remove all handlers |
+| `.before(type_key)` | `(type) -> decorator` | Register a :before advisor for a type |
+| `.after(type_key)` | `(type) -> decorator` | Register an :after advisor for a type |
+| `.around(type_key)` | `(type) -> decorator` | Register an :around advisor for a type |
+| `.unregister(func)` | `(Callable) -> None` | Remove a handler and its advisors |
+| `.clear()` | `() -> None` | Remove all handlers and advisors |
 | `.handlers()` | `() -> list[dict]` | Introspect registered handlers |
 | `dispatch(*args, **kw)` | `(*Any, **Any) -> Any` | Call the first matching handler by priority/order |
+| `.call_traced(*args, **kw)` | `(*Any, **Any) -> (Any, list[CombinationTraceEntry])` | Dispatch with per-stage trace |
 | `.call_async(*args, **kw)` | `async (*Any, **Any) -> Any` | Async dispatch |
-| `.verify_exhaustive(sealed_base)` | `(type) -> None` | Assert handlers cover all sealed subclasses |
+| `.call_async_traced(*args, **kw)` | `async (*Any, **Any) -> (Any, list[CombinationTraceEntry])` | Async dispatch with trace |
+| `.verify_exhaustive(sealed_base, *, param=None)` | `(type, *, str \| None) -> None` | Assert handlers cover all sealed subclasses |
+| `.verify_exhaustive_for(sealed_base)` | `(type) -> None` | Check all parameters referencing a sealed hierarchy |
+| `.verify_all_sealed()` | `() -> None` | Auto-discover sealed types and verify each |
+
+### `CombinationTraceEntry`
+
+NamedTuple with fields: `phase` (`"before"` | `"around"` | `"primary"` | `"after"`), `name` (str), `duration_ms` (float), `type_key` (type | None).
 
 Handler registration only supports plain runtime classes in parameter
 annotations. `typing.Any`, unions, generic aliases like `list[int]`, unresolved

--- a/live-dispatch/live_dispatch/__init__.py
+++ b/live-dispatch/live_dispatch/__init__.py
@@ -1,10 +1,12 @@
 """Runtime-extensible dispatch with multiple dispatch, predicate dispatch, and versioning."""
+from live_dispatch._combinations import CombinationTraceEntry
 from live_dispatch._dispatcher import AmbiguousDispatchError, Dispatcher
 from live_dispatch._predicate import predicate
 from live_dispatch._versioned import versioned, VersionedContext
 
 __all__ = [
     "AmbiguousDispatchError",
+    "CombinationTraceEntry",
     "Dispatcher",
     "predicate",
     "versioned",

--- a/live-dispatch/live_dispatch/_combinations.py
+++ b/live-dispatch/live_dispatch/_combinations.py
@@ -1,0 +1,262 @@
+"""CLOS-inspired method combinations for live-dispatch.
+
+Provides before/after/around advisor support for the Dispatcher class.
+
+Execution semantics:
+1. :around advisors are called outermost-first; each receives a `proceed`
+   callable as its first argument.  Calling proceed() invokes the next
+   :around or — once all :around advisors have been entered — the
+   before+primary+after chain.
+2. :before advisors run in registration order before the primary method.
+   Return values are ignored.
+3. The primary handler runs and its return value is the final result (unless
+   an :around advisor intercepts it).
+4. :after advisors run in reverse registration order after the primary method.
+   Return values are ignored.
+"""
+from __future__ import annotations
+
+import inspect
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal, NamedTuple
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+class CombinationTraceEntry(NamedTuple):
+    """A single entry in the method-combination execution trace."""
+
+    phase: Literal["before", "around", "primary", "after"]
+    name: str
+    duration_ms: float
+    type_key: type[Any] | None
+
+
+# ---------------------------------------------------------------------------
+# Internal types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Advisor:
+    """A registered advisor (before/after/around) for a specific type."""
+
+    func: Callable[..., Any]
+    phase: Literal["before", "after", "around"]
+    type_key: type[Any]
+    is_async: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.is_async = inspect.iscoroutinefunction(self.func)
+
+
+# ---------------------------------------------------------------------------
+# Combination execution helpers
+# ---------------------------------------------------------------------------
+
+def _run_combination_chain(
+    *,
+    primary_func: Callable[..., Any],
+    before_advisors: list[_Advisor],
+    after_advisors: list[_Advisor],
+    around_advisors: list[_Advisor],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    trace: list[CombinationTraceEntry] | None,
+) -> Any:
+    """Execute the synchronous method-combination chain and return the result.
+
+    If *trace* is a list, it is populated with timing entries.
+    """
+
+    def run_primary_with_before_after() -> Any:
+        # Before advisors — registration order, return values ignored.
+        for adv in before_advisors:
+            t0 = time.perf_counter()
+            adv.func(*args, **kwargs)
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="before",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+
+        # Primary handler.
+        t0 = time.perf_counter()
+        result = primary_func(*args, **kwargs)
+        duration = (time.perf_counter() - t0) * 1000.0
+        if trace is not None:
+            trace.append(CombinationTraceEntry(
+                phase="primary",
+                name=primary_func.__qualname__,
+                duration_ms=duration,
+                type_key=None,
+            ))
+
+        # After advisors — reverse registration order, return values ignored.
+        for adv in reversed(after_advisors):
+            t0 = time.perf_counter()
+            adv.func(*args, **kwargs)
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="after",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+
+        return result
+
+    if not around_advisors:
+        return run_primary_with_before_after()
+
+    # Build a nested proceed chain from inside out.
+    # around_advisors[0] is the outermost, so we build the chain starting
+    # from the innermost (run_primary_with_before_after).
+
+    def make_proceed(index: int) -> Callable[..., Any]:
+        if index >= len(around_advisors):
+            # Innermost proceed: run before+primary+after
+            def innermost_proceed(*a: Any, **kw: Any) -> Any:
+                nonlocal args, kwargs
+                args = a
+                kwargs = kw
+                return run_primary_with_before_after()
+            return innermost_proceed
+
+        adv = around_advisors[index]
+        next_proceed = make_proceed(index + 1)
+
+        def this_proceed(*a: Any, **kw: Any) -> Any:
+            nonlocal args, kwargs
+            args = a
+            kwargs = kw
+            t0 = time.perf_counter()
+            res = adv.func(next_proceed, *a, **kw)
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="around",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+            return res
+
+        return this_proceed
+
+    outermost_proceed = make_proceed(0)
+    return outermost_proceed(*args, **kwargs)
+
+
+async def _run_combination_chain_async(
+    *,
+    primary_func: Callable[..., Any],
+    before_advisors: list[_Advisor],
+    after_advisors: list[_Advisor],
+    around_advisors: list[_Advisor],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    trace: list[CombinationTraceEntry] | None,
+) -> Any:
+    """Execute the async method-combination chain and return the result.
+
+    Awaits any advisor or handler that returns a coroutine/awaitable.
+    If *trace* is a list, it is populated with timing entries.
+    """
+
+    async def run_primary_with_before_after() -> Any:
+        # Before advisors.
+        for adv in before_advisors:
+            t0 = time.perf_counter()
+            ret = adv.func(*args, **kwargs)
+            if inspect.isawaitable(ret):
+                await ret
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="before",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+
+        # Primary handler.
+        t0 = time.perf_counter()
+        ret = primary_func(*args, **kwargs)
+        if inspect.isawaitable(ret):
+            result = await ret
+        else:
+            result = ret
+        duration = (time.perf_counter() - t0) * 1000.0
+        if trace is not None:
+            trace.append(CombinationTraceEntry(
+                phase="primary",
+                name=primary_func.__qualname__,
+                duration_ms=duration,
+                type_key=None,
+            ))
+
+        # After advisors (reverse order).
+        for adv in reversed(after_advisors):
+            t0 = time.perf_counter()
+            ret = adv.func(*args, **kwargs)
+            if inspect.isawaitable(ret):
+                await ret
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="after",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+
+        return result
+
+    if not around_advisors:
+        return await run_primary_with_before_after()
+
+    # Build async nested proceed chain.
+    def make_async_proceed(index: int) -> Callable[..., Any]:
+        if index >= len(around_advisors):
+            async def innermost_proceed(*a: Any, **kw: Any) -> Any:
+                nonlocal args, kwargs
+                args = a
+                kwargs = kw
+                return await run_primary_with_before_after()
+            return innermost_proceed
+
+        adv = around_advisors[index]
+        next_proceed = make_async_proceed(index + 1)
+
+        async def this_proceed(*a: Any, **kw: Any) -> Any:
+            nonlocal args, kwargs
+            args = a
+            kwargs = kw
+            t0 = time.perf_counter()
+            ret = adv.func(next_proceed, *a, **kw)
+            if inspect.isawaitable(ret):
+                res = await ret
+            else:
+                res = ret
+            duration = (time.perf_counter() - t0) * 1000.0
+            if trace is not None:
+                trace.append(CombinationTraceEntry(
+                    phase="around",
+                    name=adv.func.__qualname__,
+                    duration_ms=duration,
+                    type_key=adv.type_key,
+                ))
+            return res
+
+        return this_proceed
+
+    outermost_proceed = make_async_proceed(0)
+    return await outermost_proceed(*args, **kwargs)

--- a/live-dispatch/live_dispatch/_dispatcher.py
+++ b/live-dispatch/live_dispatch/_dispatcher.py
@@ -7,6 +7,18 @@ import typing
 from collections.abc import Callable
 from typing import Any, Union, cast, get_args, get_origin, get_type_hints
 
+from live_dispatch._combinations import (
+    CombinationTraceEntry,
+    _Advisor,
+    _run_combination_chain,
+    _run_combination_chain_async,
+)
+from live_dispatch._sealed_glue import (
+    _covered_types_for_param,
+    _find_sealed_bases,
+    _params_referencing_sealed,
+)
+
 _Args = tuple[Any, ...]
 _Kwargs = dict[str, Any]
 # A resolved type spec value is either a plain type or a tuple of types (for Union).
@@ -62,6 +74,10 @@ class Dispatcher:
         self._fallback: _HandlerFunc | None = None
         self._cache: dict[tuple[type[Any], ...], _Handler | None] = {}
         self._has_predicates = False
+        # Method combination advisors
+        self._before_advisors: list[_Advisor] = []
+        self._after_advisors: list[_Advisor] = []
+        self._around_advisors: list[_Advisor] = []
 
     def register(
         self,
@@ -174,19 +190,172 @@ class Dispatcher:
         self._fallback = func
         return func
 
+    # ------------------------------------------------------------------
+    # Method combination decorators
+    # ------------------------------------------------------------------
+
+    def before(
+        self, type_key: type[Any]
+    ) -> Callable[[_HandlerFunc], _HandlerFunc]:
+        """Register a :before advisor for *type_key*.
+
+        The advisor runs before the primary handler whenever the first
+        argument is an instance of *type_key*.  Its return value is
+        ignored.  Multiple :before advisors run in registration order.
+
+        Usage::
+
+            @dispatch.before(Task)
+            def log_start(task: Task) -> None:
+                print(f"Starting: {task}")
+        """
+        def decorator(fn: _HandlerFunc) -> _HandlerFunc:
+            self._before_advisors.append(_Advisor(func=fn, phase="before", type_key=type_key))
+            return fn
+        return decorator
+
+    def after(
+        self, type_key: type[Any]
+    ) -> Callable[[_HandlerFunc], _HandlerFunc]:
+        """Register an :after advisor for *type_key*.
+
+        The advisor runs after the primary handler returns.  Its return
+        value is ignored.  Multiple :after advisors run in *reverse*
+        registration order.
+
+        Usage::
+
+            @dispatch.after(Task)
+            def log_end(task: Task) -> None:
+                print(f"Done: {task}")
+        """
+        def decorator(fn: _HandlerFunc) -> _HandlerFunc:
+            self._after_advisors.append(_Advisor(func=fn, phase="after", type_key=type_key))
+            return fn
+        return decorator
+
+    def around(
+        self, type_key: type[Any]
+    ) -> Callable[[_HandlerFunc], _HandlerFunc]:
+        """Register an :around advisor for *type_key*.
+
+        The advisor wraps the entire execution chain.  It receives a
+        ``proceed`` callable as its first argument followed by the
+        original call arguments.  Calling ``proceed(*args, **kwargs)``
+        invokes the next :around advisor (or the before+primary+after
+        chain when all :around advisors have been entered).  The
+        outermost :around advisor is called first.
+
+        Usage::
+
+            @dispatch.around(Task)
+            def time_it(proceed, task: Task):
+                start = time.time()
+                result = proceed(task)
+                print(f"Took {time.time() - start}s")
+                return result
+        """
+        def decorator(fn: _HandlerFunc) -> _HandlerFunc:
+            self._around_advisors.append(_Advisor(func=fn, phase="around", type_key=type_key))
+            return fn
+        return decorator
+
+    # ------------------------------------------------------------------
+    # Internal helpers for combination dispatch
+    # ------------------------------------------------------------------
+
+    def _advisors_for(
+        self,
+        args: _Args,
+    ) -> tuple[list[_Advisor], list[_Advisor], list[_Advisor]]:
+        """Return (before, after, around) advisors applicable to *args*."""
+        if not args:
+            return [], [], []
+        first = args[0]
+        before = [a for a in self._before_advisors if isinstance(first, a.type_key)]
+        after  = [a for a in self._after_advisors  if isinstance(first, a.type_key)]
+        around = [a for a in self._around_advisors if isinstance(first, a.type_key)]
+        return before, after, around
+
+    def _has_advisors_for(self, args: _Args) -> bool:
+        """Return True when any advisor matches the call arguments."""
+        if not args:
+            return False
+        first = args[0]
+        return (
+            any(isinstance(first, a.type_key) for a in self._before_advisors)
+            or any(isinstance(first, a.type_key) for a in self._after_advisors)
+            or any(isinstance(first, a.type_key) for a in self._around_advisors)
+        )
+
+    # ------------------------------------------------------------------
+    # Dispatch entry points
+    # ------------------------------------------------------------------
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Dispatch to the best matching handler."""
         handler = self._find_handler(args, kwargs)
+        primary_func: _HandlerFunc | None = None
         if handler is not None:
-            return handler.func(*args, **kwargs)
+            primary_func = handler.func
+        elif self._fallback is not None:
+            primary_func = self._fallback
+        else:
+            raise TypeError(
+                f"No handler in dispatcher '{self._name}' matches "
+                f"arguments: {_format_args(args, kwargs)}"
+            )
 
-        if self._fallback is not None:
-            return self._fallback(*args, **kwargs)
+        if not self._has_advisors_for(args):
+            return primary_func(*args, **kwargs)
 
-        raise TypeError(
-            f"No handler in dispatcher '{self._name}' matches "
-            f"arguments: {_format_args(args, kwargs)}"
+        before, after, around = self._advisors_for(args)
+        return _run_combination_chain(
+            primary_func=primary_func,
+            before_advisors=before,
+            after_advisors=after,
+            around_advisors=around,
+            args=args,
+            kwargs=kwargs,
+            trace=None,
         )
+
+    def call_traced(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[Any, list[CombinationTraceEntry]]:
+        """Dispatch and return ``(result, trace)``.
+
+        *trace* is a list of :class:`CombinationTraceEntry` objects that
+        record the phase, function name, duration, and type key for each
+        advisor and the primary handler that fired during this call.
+
+        If no advisors are registered for the matched types the trace
+        will contain only the primary entry.
+        """
+        handler = self._find_handler(args, kwargs)
+        primary_func: _HandlerFunc | None = None
+        if handler is not None:
+            primary_func = handler.func
+        elif self._fallback is not None:
+            primary_func = self._fallback
+        else:
+            raise TypeError(
+                f"No handler in dispatcher '{self._name}' matches "
+                f"arguments: {_format_args(args, kwargs)}"
+            )
+
+        trace: list[CombinationTraceEntry] = []
+        before, after, around = self._advisors_for(args)
+        result = _run_combination_chain(
+            primary_func=primary_func,
+            before_advisors=before,
+            after_advisors=after,
+            around_advisors=around,
+            args=args,
+            kwargs=kwargs,
+            trace=trace,
+        )
+        return result, trace
 
     def handlers(self) -> list[dict[str, Any]]:
         """Introspect registered handlers."""
@@ -201,15 +370,21 @@ class Dispatcher:
         ]
 
     def unregister(self, func: _HandlerFunc) -> None:
-        """Remove a handler by function reference."""
+        """Remove a handler and any advisors registered from *func*."""
         self._handlers = [h for h in self._handlers if h.func is not func]
+        self._before_advisors = [a for a in self._before_advisors if a.func is not func]
+        self._after_advisors  = [a for a in self._after_advisors  if a.func is not func]
+        self._around_advisors = [a for a in self._around_advisors if a.func is not func]
         self._refresh_predicate_state()
         self._cache.clear()
 
     def clear(self) -> None:
-        """Remove all handlers."""
+        """Remove all handlers and advisors."""
         self._handlers.clear()
         self._fallback = None
+        self._before_advisors.clear()
+        self._after_advisors.clear()
+        self._around_advisors.clear()
         self._refresh_predicate_state()
         self._cache.clear()
 
@@ -301,46 +476,108 @@ class Dispatcher:
     async def call_async(self, *args: Any, **kwargs: Any) -> Any:
         """Async dispatch — calls the handler and awaits if it returns a coroutine."""
         handler = self._find_handler(args, kwargs)
+        primary_func: _HandlerFunc | None = None
         if handler is not None:
-            result = handler.func(*args, **kwargs)
+            primary_func = handler.func
+        elif self._fallback is not None:
+            primary_func = self._fallback
+        else:
+            raise TypeError(
+                f"No handler in dispatcher '{self._name}' matches "
+                f"arguments: {_format_args(args, kwargs)}"
+            )
+
+        if not self._has_advisors_for(args):
+            result = primary_func(*args, **kwargs)
             if inspect.isawaitable(result):
                 return await result
             return result
 
-        if self._fallback is not None:
-            result = self._fallback(*args, **kwargs)
-            if inspect.isawaitable(result):
-                return await result
-            return result
-
-        raise TypeError(
-            f"No handler in dispatcher '{self._name}' matches "
-            f"arguments: {_format_args(args, kwargs)}"
+        before, after, around = self._advisors_for(args)
+        return await _run_combination_chain_async(
+            primary_func=primary_func,
+            before_advisors=before,
+            after_advisors=after,
+            around_advisors=around,
+            args=args,
+            kwargs=kwargs,
+            trace=None,
         )
 
-    def verify_exhaustive(self, sealed_base: type[Any]) -> None:
+    async def call_async_traced(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[Any, list[CombinationTraceEntry]]:
+        """Async dispatch returning ``(result, trace)``.
+
+        Like :meth:`call_traced` but for async handlers and advisors.
+        """
+        handler = self._find_handler(args, kwargs)
+        primary_func: _HandlerFunc | None = None
+        if handler is not None:
+            primary_func = handler.func
+        elif self._fallback is not None:
+            primary_func = self._fallback
+        else:
+            raise TypeError(
+                f"No handler in dispatcher '{self._name}' matches "
+                f"arguments: {_format_args(args, kwargs)}"
+            )
+
+        trace: list[CombinationTraceEntry] = []
+        before, after, around = self._advisors_for(args)
+        result = await _run_combination_chain_async(
+            primary_func=primary_func,
+            before_advisors=before,
+            after_advisors=after,
+            around_advisors=around,
+            args=args,
+            kwargs=kwargs,
+            trace=trace,
+        )
+        return result, trace
+
+    # ------------------------------------------------------------------
+    # Sealed-type exhaustiveness verification
+    # ------------------------------------------------------------------
+
+    def verify_exhaustive(
+        self,
+        sealed_base: type[Any],
+        *,
+        param: str | None = None,
+    ) -> None:
         """Assert that registered handlers cover all sealed subclasses.
 
         Args:
             sealed_base: A class decorated with @sealed from sealed_typing.
+            param: Optional parameter name.  When given, only handlers that
+                   annotate *param* are considered; coverage is checked
+                   per that parameter.  When omitted, all typed parameters
+                   across all handlers are searched (original behaviour).
 
         Raises:
-            TypeError: If the sealed base has subclasses not covered by handlers,
-                       or if sealed_base is not a sealed class.
+            TypeError: If the sealed base has subclasses not covered by
+                       handlers, or if sealed_base is not a sealed class.
         """
         if not getattr(sealed_base, '__sealed__', False):
             raise TypeError(f"'{sealed_base.__qualname__}' is not a sealed class")
 
         sealed_subs = frozenset(getattr(sealed_base, '__sealed_subclasses__', set()))
-        covered_types: set[type[Any]] = set()
-        for h in self._handlers:
-            for resolved in h.type_spec.values():
-                if isinstance(resolved, tuple):
-                    for t in resolved:
-                        if isinstance(t, type):
-                            covered_types.add(t)
-                elif isinstance(resolved, type):
-                    covered_types.add(resolved)
+
+        if param is not None:
+            # Per-parameter coverage check.
+            covered_types: set[type[Any]] = _covered_types_for_param(self._handlers, param)
+        else:
+            # Original behaviour: collect types from ALL parameters.
+            covered_types = set()
+            for h in self._handlers:
+                for resolved in h.type_spec.values():
+                    if isinstance(resolved, tuple):
+                        for t in resolved:
+                            if isinstance(t, type):
+                                covered_types.add(t)
+                    elif isinstance(resolved, type):
+                        covered_types.add(resolved)
 
         missing = sealed_subs - covered_types
         if missing:
@@ -350,6 +587,56 @@ class Dispatcher:
                 f"sealed class '{sealed_base.__qualname__}'. "
                 f"Missing: {missing_names}"
             )
+
+    def verify_exhaustive_for(self, sealed_base: type[Any]) -> None:
+        """Check ALL typed parameters that reference *sealed_base*.
+
+        Finds every parameter name across all handlers whose type annotation
+        includes *sealed_base* or any of its registered subclasses, then
+        verifies that for each such parameter name, every sealed subclass is
+        covered by at least one handler annotating that same parameter.
+
+        Args:
+            sealed_base: A class decorated with @sealed from sealed_typing.
+
+        Raises:
+            TypeError: If sealed_base is not a sealed class, or if any
+                       parameter that references the sealed hierarchy does not
+                       fully cover all subclasses.
+        """
+        if not getattr(sealed_base, '__sealed__', False):
+            raise TypeError(f"'{sealed_base.__qualname__}' is not a sealed class")
+
+        param_names = _params_referencing_sealed(self._handlers, sealed_base)
+        if not param_names:
+            return
+
+        sealed_subs = frozenset(getattr(sealed_base, '__sealed_subclasses__', set()))
+        for pname in sorted(param_names):
+            covered = _covered_types_for_param(self._handlers, pname)
+            missing = sealed_subs - covered
+            if missing:
+                missing_names = ', '.join(sorted(c.__qualname__ for c in missing))
+                raise TypeError(
+                    f"Dispatcher '{self._name}' parameter '{pname}' does not cover "
+                    f"all subclasses of sealed class '{sealed_base.__qualname__}'. "
+                    f"Missing: {missing_names}"
+                )
+
+    def verify_all_sealed(self) -> None:
+        """Auto-discover all sealed types in handlers and verify each one.
+
+        Scans every handler's type_spec for types whose ancestors are sealed
+        classes, then calls :meth:`verify_exhaustive_for` for each discovered
+        sealed base.
+
+        Raises:
+            TypeError: If any sealed type is not fully covered for every
+                       parameter that references it.
+        """
+        sealed_bases = _find_sealed_bases(self._handlers)
+        for base in sorted(sealed_bases, key=lambda c: c.__qualname__):
+            self.verify_exhaustive_for(base)
 
     def __repr__(self) -> str:
         return f"Dispatcher('{self._name}', handlers={len(self._handlers)})"

--- a/live-dispatch/live_dispatch/_sealed_glue.py
+++ b/live-dispatch/live_dispatch/_sealed_glue.py
@@ -1,0 +1,75 @@
+"""Helper utilities for sealed-typing integration with live-dispatch."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from live_dispatch._dispatcher import _Handler, _ResolvedType
+
+
+def _iter_types_in_spec(resolved: "_ResolvedType") -> list[type[Any]]:
+    """Yield all concrete types contained in a resolved type-spec value."""
+    if isinstance(resolved, tuple):
+        return [t for t in resolved if isinstance(t, type)]
+    if isinstance(resolved, type):
+        return [resolved]
+    return []
+
+
+def _find_sealed_bases(handlers: "list[_Handler]") -> set[type[Any]]:
+    """Scan all handlers' type_specs and return the set of sealed base classes.
+
+    A sealed base is a class whose ``__sealed__`` attribute is ``True``
+    (set by ``@sealed`` from sealed-typing).  We walk the MRO of every type
+    that appears in any handler's type_spec, collecting classes that are
+    themselves sealed bases.
+    """
+    sealed_bases: set[type[Any]] = set()
+    for handler in handlers:
+        for resolved in handler.type_spec.values():
+            for t in _iter_types_in_spec(resolved):
+                for ancestor in t.__mro__:
+                    if ancestor.__dict__.get("__sealed__", False) is True:
+                        sealed_bases.add(ancestor)
+    return sealed_bases
+
+
+def _covered_types_for_param(
+    handlers: "list[_Handler]",
+    param_name: str,
+) -> set[type[Any]]:
+    """Return the set of all types registered for *param_name* across handlers.
+
+    Only handlers that have an explicit type annotation for *param_name* are
+    considered.
+    """
+    covered: set[type[Any]] = set()
+    for handler in handlers:
+        resolved = handler.type_spec.get(param_name)
+        if resolved is None:
+            continue
+        for t in _iter_types_in_spec(resolved):
+            covered.add(t)
+    return covered
+
+
+def _params_referencing_sealed(
+    handlers: "list[_Handler]",
+    sealed_base: type[Any],
+) -> set[str]:
+    """Return parameter names whose annotations reference *sealed_base* or any
+    of its registered subclasses.
+    """
+    sealed_subs: frozenset[type[Any]] = frozenset(
+        getattr(sealed_base, "__sealed_subclasses__", set())
+    )
+    relevant_types = sealed_subs | {sealed_base}
+
+    param_names: set[str] = set()
+    for handler in handlers:
+        for param_name, resolved in handler.type_spec.items():
+            for t in _iter_types_in_spec(resolved):
+                if t in relevant_types:
+                    param_names.add(param_name)
+                    break
+    return param_names

--- a/live-dispatch/pyproject.toml
+++ b/live-dispatch/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "live-dispatch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Runtime-extensible dispatch with multiple dispatch, predicate dispatch, and versioning"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/live-dispatch/tests/test_combinations.py
+++ b/live-dispatch/tests/test_combinations.py
@@ -1,0 +1,815 @@
+"""Tests for CLOS-inspired method combinations on Dispatcher."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from live_dispatch import CombinationTraceEntry, Dispatcher
+
+
+# ---------------------------------------------------------------------------
+# Helper types
+# ---------------------------------------------------------------------------
+
+class Animal:
+    pass
+
+class Dog(Animal):
+    pass
+
+class Cat(Animal):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Basic before/after/around execution order
+# ---------------------------------------------------------------------------
+
+def test_before_runs_before_primary():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "done"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    result = d(Animal())
+    assert result == "done"
+    assert log == ["before", "primary"]
+
+
+def test_after_runs_after_primary():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "done"
+
+    @d.after(Animal)
+    def post(x: Animal) -> None:
+        log.append("after")
+
+    result = d(Animal())
+    assert result == "done"
+    assert log == ["primary", "after"]
+
+
+def test_before_after_around_order():
+    """Full order: around_enter -> before -> primary -> after -> around_exit."""
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "done"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    @d.after(Animal)
+    def post(x: Animal) -> None:
+        log.append("after")
+
+    @d.around(Animal)
+    def wrap(proceed, x: Animal) -> str:
+        log.append("around_enter")
+        result = proceed(x)
+        log.append("around_exit")
+        return result
+
+    result = d(Animal())
+    assert result == "done"
+    assert log == ["around_enter", "before", "primary", "after", "around_exit"]
+
+
+# ---------------------------------------------------------------------------
+# Multiple before advisors run in registration order
+# ---------------------------------------------------------------------------
+
+def test_multiple_before_registration_order():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "primary"
+
+    @d.before(Animal)
+    def before1(x: Animal) -> None:
+        log.append("before1")
+
+    @d.before(Animal)
+    def before2(x: Animal) -> None:
+        log.append("before2")
+
+    @d.before(Animal)
+    def before3(x: Animal) -> None:
+        log.append("before3")
+
+    d(Animal())
+    assert log == ["before1", "before2", "before3"]
+
+
+# ---------------------------------------------------------------------------
+# Multiple after advisors run in reverse registration order
+# ---------------------------------------------------------------------------
+
+def test_multiple_after_reverse_order():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "primary"
+
+    @d.after(Animal)
+    def after1(x: Animal) -> None:
+        log.append("after1")
+
+    @d.after(Animal)
+    def after2(x: Animal) -> None:
+        log.append("after2")
+
+    @d.after(Animal)
+    def after3(x: Animal) -> None:
+        log.append("after3")
+
+    d(Animal())
+    assert log == ["after3", "after2", "after1"]
+
+
+# ---------------------------------------------------------------------------
+# Around advisors nest correctly (outermost first)
+# ---------------------------------------------------------------------------
+
+def test_multiple_around_nesting():
+    """Outermost :around runs first; innermost wraps closest to primary."""
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "done"
+
+    @d.around(Animal)
+    def outer(proceed, x: Animal) -> str:
+        log.append("outer_enter")
+        result = proceed(x)
+        log.append("outer_exit")
+        return result
+
+    @d.around(Animal)
+    def inner(proceed, x: Animal) -> str:
+        log.append("inner_enter")
+        result = proceed(x)
+        log.append("inner_exit")
+        return result
+
+    d(Animal())
+    assert log == ["outer_enter", "inner_enter", "primary", "inner_exit", "outer_exit"]
+
+
+# ---------------------------------------------------------------------------
+# Traced execution
+# ---------------------------------------------------------------------------
+
+def test_call_traced_phases():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "result"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        pass
+
+    @d.after(Animal)
+    def post(x: Animal) -> None:
+        pass
+
+    result, trace = d.call_traced(Animal())
+    assert result == "result"
+    phases = [e.phase for e in trace]
+    assert phases == ["before", "primary", "after"]
+
+
+def test_call_traced_names():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle_animal(x: Animal) -> str:
+        return "result"
+
+    @d.before(Animal)
+    def pre_animal(x: Animal) -> None:
+        pass
+
+    result, trace = d.call_traced(Animal())
+    names = [e.name for e in trace]
+    assert "pre_animal" in names[0]
+    assert "handle_animal" in names[1]
+
+
+def test_call_traced_duration_ms_non_negative():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        pass
+
+    _, trace = d.call_traced(Animal())
+    for entry in trace:
+        assert entry.duration_ms >= 0.0
+
+
+def test_call_traced_type_key():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        pass
+
+    @d.after(Animal)
+    def post(x: Animal) -> None:
+        pass
+
+    _, trace = d.call_traced(Animal())
+    before_entry = next(e for e in trace if e.phase == "before")
+    after_entry  = next(e for e in trace if e.phase == "after")
+    primary_entry = next(e for e in trace if e.phase == "primary")
+
+    assert before_entry.type_key is Animal
+    assert after_entry.type_key is Animal
+    assert primary_entry.type_key is None
+
+
+def test_call_traced_around_entry():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.around(Animal)
+    def wrap(proceed, x: Animal) -> str:
+        return proceed(x)
+
+    _, trace = d.call_traced(Animal())
+    phases = [e.phase for e in trace]
+    assert "around" in phases
+    around_entry = next(e for e in trace if e.phase == "around")
+    assert around_entry.type_key is Animal
+
+
+def test_call_traced_no_advisors_primary_only():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    result, trace = d.call_traced(Animal())
+    assert result == "r"
+    assert len(trace) == 1
+    assert trace[0].phase == "primary"
+
+
+# ---------------------------------------------------------------------------
+# Async combinations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_async_before():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    async def handle(x: Animal) -> str:
+        log.append("primary")
+        return "async_result"
+
+    @d.before(Animal)
+    async def pre(x: Animal) -> None:
+        await asyncio.sleep(0)
+        log.append("async_before")
+
+    result = await d.call_async(Animal())
+    assert result == "async_result"
+    assert log == ["async_before", "primary"]
+
+
+@pytest.mark.asyncio
+async def test_async_after():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    async def handle(x: Animal) -> str:
+        log.append("primary")
+        return "result"
+
+    @d.after(Animal)
+    async def post(x: Animal) -> None:
+        await asyncio.sleep(0)
+        log.append("async_after")
+
+    result = await d.call_async(Animal())
+    assert result == "result"
+    assert log == ["primary", "async_after"]
+
+
+@pytest.mark.asyncio
+async def test_async_around():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    async def handle(x: Animal) -> str:
+        log.append("primary")
+        return "result"
+
+    @d.around(Animal)
+    async def wrap(proceed, x: Animal) -> str:
+        log.append("around_enter")
+        result = await proceed(x)
+        log.append("around_exit")
+        return result
+
+    result = await d.call_async(Animal())
+    assert result == "result"
+    assert log == ["around_enter", "primary", "around_exit"]
+
+
+@pytest.mark.asyncio
+async def test_async_call_async_traced():
+    d = Dispatcher("test")
+
+    @d.register
+    async def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    async def pre(x: Animal) -> None:
+        pass
+
+    @d.after(Animal)
+    async def post(x: Animal) -> None:
+        pass
+
+    result, trace = await d.call_async_traced(Animal())
+    assert result == "r"
+    phases = [e.phase for e in trace]
+    assert "before" in phases
+    assert "primary" in phases
+    assert "after" in phases
+
+
+@pytest.mark.asyncio
+async def test_async_mixed_sync_async_advisors():
+    """Sync and async advisors can be mixed in the chain."""
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "r"
+
+    @d.before(Animal)
+    def sync_before(x: Animal) -> None:
+        log.append("sync_before")
+
+    @d.before(Animal)
+    async def async_before(x: Animal) -> None:
+        await asyncio.sleep(0)
+        log.append("async_before")
+
+    result = await d.call_async(Animal())
+    assert result == "r"
+    assert log == ["sync_before", "async_before", "primary"]
+
+
+# ---------------------------------------------------------------------------
+# Interaction with specificity dispatch
+# ---------------------------------------------------------------------------
+
+def test_combinations_with_specificity():
+    d = Dispatcher("test", specificity=True)
+    log: list[str] = []
+
+    @d.register
+    def handle_animal(x: Animal) -> str:
+        log.append("animal_primary")
+        return "animal"
+
+    @d.register
+    def handle_dog(x: Dog) -> str:
+        log.append("dog_primary")
+        return "dog"
+
+    @d.before(Dog)
+    def dog_before(x: Dog) -> None:
+        log.append("dog_before")
+
+    # Dog-specific handler wins for Dog
+    result = d(Dog())
+    assert result == "dog"
+    assert log == ["dog_before", "dog_primary"]
+
+    log.clear()
+
+    # Animal handler for Cat (no Dog advisor fires)
+    result = d(Cat())
+    assert result == "animal"
+    assert "dog_before" not in log
+
+
+# ---------------------------------------------------------------------------
+# Interaction with priority
+# ---------------------------------------------------------------------------
+
+def test_combinations_with_priority():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register(priority=0)
+    def low(x: Animal) -> str:
+        log.append("low")
+        return "low"
+
+    @d.register(priority=10)
+    def high(x: Animal) -> str:
+        log.append("high")
+        return "high"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    result = d(Animal())
+    # High priority handler wins
+    assert result == "high"
+    assert log == ["before", "high"]
+
+
+# ---------------------------------------------------------------------------
+# Around can modify arguments to proceed
+# ---------------------------------------------------------------------------
+
+def test_around_modifies_arguments():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: int) -> int:
+        return x * 2
+
+    @d.around(int)
+    def double_input(proceed, x: int) -> int:
+        return proceed(x + 10)
+
+    result = d(5)
+    # around passes x+10=15 to primary, primary returns 15*2=30
+    assert result == 30
+
+
+# ---------------------------------------------------------------------------
+# Around can modify return value
+# ---------------------------------------------------------------------------
+
+def test_around_modifies_return_value():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: int) -> int:
+        return x
+
+    @d.around(int)
+    def negate_result(proceed, x: int) -> int:
+        return -proceed(x)
+
+    result = d(7)
+    assert result == -7
+
+
+# ---------------------------------------------------------------------------
+# No advisors = normal dispatch (backward compatibility)
+# ---------------------------------------------------------------------------
+
+def test_no_advisors_backward_compatible():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: int) -> str:
+        return f"int:{x}"
+
+    assert d(42) == "int:42"
+
+
+def test_no_advisors_multiple_handlers():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle_int(x: int) -> str:
+        return "int"
+
+    @d.register
+    def handle_str(x: str) -> str:
+        return "str"
+
+    assert d(1) == "int"
+    assert d("hi") == "str"
+
+
+# ---------------------------------------------------------------------------
+# Type-specific advisors only fire for matching types
+# ---------------------------------------------------------------------------
+
+def test_type_specific_advisors():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle_animal(x: Animal) -> str:
+        return "animal"
+
+    @d.before(Dog)
+    def dog_only_before(x: Dog) -> None:
+        log.append("dog_before")
+
+    # Dog is a subtype of Animal, so Dog-specific advisor fires for Dog
+    d(Dog())
+    assert "dog_before" in log
+
+    log.clear()
+
+    # Cat does NOT match Dog advisor
+    d(Cat())
+    assert "dog_before" not in log
+
+
+def test_subclass_inherits_parent_advisors():
+    """Advisors on Animal also fire for Dog (isinstance check)."""
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "animal"
+
+    @d.before(Animal)
+    def animal_before(x: Animal) -> None:
+        log.append("animal_before")
+
+    d(Dog())  # Dog is an Animal
+    assert "animal_before" in log
+
+
+# ---------------------------------------------------------------------------
+# Unregister/clear also clears advisors
+# ---------------------------------------------------------------------------
+
+def test_unregister_removes_advisor():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    d.unregister(pre)
+    d(Animal())
+    assert log == []
+
+
+def test_clear_removes_all_advisors():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    @d.after(Animal)
+    def post(x: Animal) -> None:
+        log.append("after")
+
+    @d.around(Animal)
+    def wrap(proceed, x: Animal) -> str:
+        log.append("around")
+        return proceed(x)
+
+    d.clear()
+    assert d._before_advisors == []
+    assert d._after_advisors == []
+    assert d._around_advisors == []
+
+
+def test_clear_then_fresh_registration():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "r"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    d.clear()
+
+    # Re-register without advisor
+    @d.register
+    def handle2(x: Animal) -> str:
+        return "r2"
+
+    result = d(Animal())
+    assert result == "r2"
+    assert log == []
+
+
+# ---------------------------------------------------------------------------
+# CombinationTraceEntry is a NamedTuple with correct fields
+# ---------------------------------------------------------------------------
+
+def test_combination_trace_entry_fields():
+    entry = CombinationTraceEntry(
+        phase="before",
+        name="my_func",
+        duration_ms=1.5,
+        type_key=Animal,
+    )
+    assert entry.phase == "before"
+    assert entry.name == "my_func"
+    assert entry.duration_ms == 1.5
+    assert entry.type_key is Animal
+
+
+def test_combination_trace_entry_is_named_tuple():
+    entry = CombinationTraceEntry(phase="primary", name="f", duration_ms=0.1, type_key=None)
+    # NamedTuple supports indexing
+    assert entry[0] == "primary"
+    assert entry[1] == "f"
+
+
+# ---------------------------------------------------------------------------
+# Before/after return values are ignored
+# ---------------------------------------------------------------------------
+
+def test_before_return_value_ignored():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "primary_result"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> str:
+        return "should_be_ignored"
+
+    result = d(Animal())
+    assert result == "primary_result"
+
+
+def test_after_return_value_ignored():
+    d = Dispatcher("test")
+
+    @d.register
+    def handle(x: Animal) -> str:
+        return "primary_result"
+
+    @d.after(Animal)
+    def post(x: Animal) -> str:
+        return "should_be_ignored"
+
+    result = d(Animal())
+    assert result == "primary_result"
+
+
+# ---------------------------------------------------------------------------
+# Fallback handler with combinations
+# ---------------------------------------------------------------------------
+
+def test_combinations_with_fallback():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle_int(x: int) -> str:
+        return "int"
+
+    @d.fallback
+    def catch_all(*args: Any) -> str:
+        log.append("fallback")
+        return "fallback"
+
+    @d.before(str)
+    def pre_str(x: str) -> None:
+        log.append("before_str")
+
+    # Falls back, but before_str fires (str is an instance of str)
+    result = d("hello")
+    assert result == "fallback"
+    assert "before_str" in log
+
+
+# ---------------------------------------------------------------------------
+# Around stops the chain when proceed is not called
+# ---------------------------------------------------------------------------
+
+def test_around_can_short_circuit():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    def handle(x: Animal) -> str:
+        log.append("primary")
+        return "primary_result"
+
+    @d.before(Animal)
+    def pre(x: Animal) -> None:
+        log.append("before")
+
+    @d.around(Animal)
+    def short_circuit(proceed, x: Animal) -> str:
+        # Deliberately does NOT call proceed
+        log.append("around_short_circuit")
+        return "short_circuited"
+
+    result = d(Animal())
+    assert result == "short_circuited"
+    # before and primary should NOT have run
+    assert "before" not in log
+    assert "primary" not in log
+    assert "around_short_circuit" in log
+
+
+# ---------------------------------------------------------------------------
+# Async around nesting
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_async_around_nesting():
+    d = Dispatcher("test")
+    log: list[str] = []
+
+    @d.register
+    async def handle(x: Animal) -> str:
+        log.append("primary")
+        return "done"
+
+    @d.around(Animal)
+    async def outer(proceed, x: Animal) -> str:
+        log.append("outer_enter")
+        result = await proceed(x)
+        log.append("outer_exit")
+        return result
+
+    @d.around(Animal)
+    async def inner(proceed, x: Animal) -> str:
+        log.append("inner_enter")
+        result = await proceed(x)
+        log.append("inner_exit")
+        return result
+
+    result = await d.call_async(Animal())
+    assert result == "done"
+    assert log == ["outer_enter", "inner_enter", "primary", "inner_exit", "outer_exit"]
+
+
+# ---------------------------------------------------------------------------
+# Export verification
+# ---------------------------------------------------------------------------
+
+def test_combination_trace_entry_exported_from_package():
+    from live_dispatch import CombinationTraceEntry as CTE
+    assert CTE is CombinationTraceEntry

--- a/live-dispatch/tests/test_sealed_glue.py
+++ b/live-dispatch/tests/test_sealed_glue.py
@@ -1,0 +1,500 @@
+"""Tests for sealed-typing / live-dispatch exhaustiveness glue.
+
+All classes that appear in type annotations must be defined at module level
+so that get_type_hints() can resolve them.
+"""
+from __future__ import annotations
+
+import pytest
+from live_dispatch import Dispatcher
+from sealed_typing import sealed, verify_dispatch_exhaustive
+
+
+# ---------------------------------------------------------------------------
+# Sealed hierarchies used across tests
+# ---------------------------------------------------------------------------
+
+@sealed
+class Shape:
+    """Simple sealed hierarchy: Shape -> Circle, Square, Triangle."""
+
+
+class Circle(Shape):
+    pass
+
+
+class Square(Shape):
+    pass
+
+
+class Triangle(Shape):
+    pass
+
+
+@sealed
+class Color:
+    """Second sealed hierarchy for multi-param and multi-sealed tests."""
+
+
+class Red(Color):
+    pass
+
+
+class Green(Color):
+    pass
+
+
+class Blue(Color):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# verify_exhaustive — per-parameter (param=) mode
+# ---------------------------------------------------------------------------
+
+def test_verify_exhaustive_param_full_coverage():
+    """param= mode: passes when all subclasses are covered for the given param."""
+    d = Dispatcher("shapes")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    # Should not raise
+    d.verify_exhaustive(Shape, param="x")
+
+
+def test_verify_exhaustive_param_missing_subclass():
+    """param= mode: fails when a subclass is missing for the given param."""
+    d = Dispatcher("shapes")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    # Missing Triangle for param 'x'
+    with pytest.raises(TypeError, match="Triangle"):
+        d.verify_exhaustive(Shape, param="x")
+
+
+def test_verify_exhaustive_param_wrong_param_name():
+    """param= mode: checking a param that no handler uses raises about all subs."""
+    d = Dispatcher("shapes")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    # param='y' — no handler annotates 'y', so coverage is empty
+    with pytest.raises(TypeError, match="Missing"):
+        d.verify_exhaustive(Shape, param="y")
+
+
+def test_verify_exhaustive_param_multi_dispatch():
+    """param= mode only inspects the named param, even in multi-param handlers."""
+    d = Dispatcher("shapes_multi")
+
+    @d.register
+    def on_circle_red(x: Circle, y: Red) -> str:
+        return "circle+red"
+
+    @d.register
+    def on_square_red(x: Square, y: Red) -> str:
+        return "square+red"
+
+    @d.register
+    def on_triangle_red(x: Triangle, y: Red) -> str:
+        return "triangle+red"
+
+    # 'x' is fully covered for Shape
+    d.verify_exhaustive(Shape, param="x")
+
+    # 'y' has only Red — not exhaustive for Color
+    with pytest.raises(TypeError, match="Missing"):
+        d.verify_exhaustive(Color, param="y")
+
+
+# ---------------------------------------------------------------------------
+# verify_exhaustive — backward-compatible (no param) mode
+# ---------------------------------------------------------------------------
+
+def test_verify_exhaustive_no_param_full_coverage():
+    """Backward compat: no-param mode still works when all subs are covered."""
+    d = Dispatcher("shapes_compat")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    d.verify_exhaustive(Shape)  # must not raise
+
+
+def test_verify_exhaustive_no_param_missing():
+    """Backward compat: no-param mode raises when a subclass is missing."""
+    d = Dispatcher("shapes_compat")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    with pytest.raises(TypeError, match="Missing"):
+        d.verify_exhaustive(Shape)
+
+
+def test_verify_exhaustive_not_sealed():
+    """Both modes raise TypeError when sealed_base is not a sealed class."""
+    d = Dispatcher("test_ns")
+
+    class NotSealed:
+        pass
+
+    with pytest.raises(TypeError, match="not a sealed class"):
+        d.verify_exhaustive(NotSealed)
+
+    with pytest.raises(TypeError, match="not a sealed class"):
+        d.verify_exhaustive(NotSealed, param="x")
+
+
+def test_verify_exhaustive_union_param():
+    """Union annotations count both types for coverage."""
+    d = Dispatcher("union_shapes")
+
+    @d.register
+    def on_circle_or_square(x: Circle | Square) -> str:
+        return "circle_or_square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    # Circle and Square covered via Union, Triangle via direct annotation
+    d.verify_exhaustive(Shape, param="x")
+    d.verify_exhaustive(Shape)  # backward compat also works
+
+
+# ---------------------------------------------------------------------------
+# verify_exhaustive_for
+# ---------------------------------------------------------------------------
+
+def test_verify_exhaustive_for_full_coverage():
+    """verify_exhaustive_for passes when all params referencing sealed are covered."""
+    d = Dispatcher("shapes_for")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    d.verify_exhaustive_for(Shape)  # must not raise
+
+
+def test_verify_exhaustive_for_fails_on_incomplete_param():
+    """verify_exhaustive_for fails when one param has incomplete coverage."""
+    d = Dispatcher("shapes_for_fail")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    # Triangle missing on param 'x'
+    with pytest.raises(TypeError, match="Triangle"):
+        d.verify_exhaustive_for(Shape)
+
+
+def test_verify_exhaustive_for_no_handlers_referencing_sealed():
+    """verify_exhaustive_for is a no-op when no handlers reference the sealed type."""
+    d = Dispatcher("unrelated")
+
+    @d.register
+    def on_int(x: int) -> str:
+        return "int"
+
+    # Shape is sealed, but no handler references it — should pass silently
+    d.verify_exhaustive_for(Shape)
+
+
+def test_verify_exhaustive_for_not_sealed():
+    """verify_exhaustive_for raises TypeError for non-sealed classes."""
+    d = Dispatcher("test_vef_ns")
+
+    class NotSealed:
+        pass
+
+    with pytest.raises(TypeError, match="not a sealed class"):
+        d.verify_exhaustive_for(NotSealed)
+
+
+def test_verify_exhaustive_for_multi_param():
+    """verify_exhaustive_for checks ALL params that reference the sealed hierarchy."""
+    d = Dispatcher("shapes_color")
+
+    # 'x' covers all of Shape; 'y' covers all of Color
+    @d.register
+    def on_circle_red(x: Circle, y: Red) -> str:
+        return "cr"
+
+    @d.register
+    def on_square_green(x: Square, y: Green) -> str:
+        return "sg"
+
+    @d.register
+    def on_triangle_blue(x: Triangle, y: Blue) -> str:
+        return "tb"
+
+    # Each param is individually exhaustive
+    d.verify_exhaustive_for(Shape)
+    d.verify_exhaustive_for(Color)
+
+
+def test_verify_exhaustive_for_multi_param_incomplete():
+    """verify_exhaustive_for fails if only ONE param is incomplete."""
+    d = Dispatcher("shapes_color_incomplete")
+
+    @d.register
+    def on_circle(x: Circle, y: Red) -> str:
+        return "cr"
+
+    @d.register
+    def on_square(x: Square, y: Green) -> str:
+        return "sg"
+
+    # Triangle missing for 'x'; Blue missing for 'y'
+    with pytest.raises(TypeError, match="Triangle|Blue"):
+        d.verify_exhaustive_for(Shape)
+
+
+# ---------------------------------------------------------------------------
+# verify_all_sealed
+# ---------------------------------------------------------------------------
+
+def test_verify_all_sealed_full_coverage():
+    """verify_all_sealed passes when every discovered sealed base is fully covered."""
+    d = Dispatcher("all_sealed")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    d.verify_all_sealed()  # must not raise
+
+
+def test_verify_all_sealed_no_sealed_types():
+    """verify_all_sealed is a no-op when handlers have no sealed types."""
+    d = Dispatcher("no_sealed")
+
+    @d.register
+    def on_int(x: int) -> str:
+        return "int"
+
+    @d.register
+    def on_str(x: str) -> str:
+        return "str"
+
+    d.verify_all_sealed()  # no-op, must not raise
+
+
+def test_verify_all_sealed_empty_dispatcher():
+    """verify_all_sealed is a no-op on an empty dispatcher."""
+    d = Dispatcher("empty_all")
+    d.verify_all_sealed()  # must not raise
+
+
+def test_verify_all_sealed_fails_on_incomplete():
+    """verify_all_sealed raises when any discovered sealed type is not exhaustive."""
+    d = Dispatcher("all_sealed_fail")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    # Triangle missing
+    with pytest.raises(TypeError, match="Triangle"):
+        d.verify_all_sealed()
+
+
+def test_verify_all_sealed_multi_hierarchy():
+    """verify_all_sealed checks all sealed hierarchies present in handlers."""
+    d = Dispatcher("multi_hier")
+
+    @d.register
+    def h1(x: Circle, y: Red) -> str:
+        return "cr"
+
+    @d.register
+    def h2(x: Square, y: Green) -> str:
+        return "sg"
+
+    @d.register
+    def h3(x: Triangle, y: Blue) -> str:
+        return "tb"
+
+    # Both Shape and Color hierarchies fully covered
+    d.verify_all_sealed()
+
+
+def test_verify_all_sealed_multi_hierarchy_one_incomplete():
+    """verify_all_sealed fails when one of multiple hierarchies is incomplete."""
+    d = Dispatcher("multi_hier_fail")
+
+    @d.register
+    def h1(x: Circle, y: Red) -> str:
+        return "cr"
+
+    @d.register
+    def h2(x: Square, y: Green) -> str:
+        return "sg"
+
+    # Triangle missing for 'x'; Blue missing for 'y'
+    with pytest.raises(TypeError, match="Blue|Triangle"):
+        d.verify_all_sealed()
+
+
+# ---------------------------------------------------------------------------
+# verify_dispatch_exhaustive (sealed-typing convenience)
+# ---------------------------------------------------------------------------
+
+def test_verify_dispatch_exhaustive_delegates():
+    """verify_dispatch_exhaustive calls dispatcher.verify_exhaustive."""
+    d = Dispatcher("vde_test")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    # Should not raise
+    verify_dispatch_exhaustive(d, Shape)
+
+
+def test_verify_dispatch_exhaustive_fails_when_missing():
+    """verify_dispatch_exhaustive propagates failure from the dispatcher."""
+    d = Dispatcher("vde_fail")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    with pytest.raises(TypeError, match="Missing"):
+        verify_dispatch_exhaustive(d, Shape)
+
+
+def test_verify_dispatch_exhaustive_not_a_dispatcher():
+    """verify_dispatch_exhaustive raises TypeError for non-dispatcher objects."""
+    with pytest.raises(TypeError, match="verify_exhaustive"):
+        verify_dispatch_exhaustive("not a dispatcher", Shape)  # type: ignore[arg-type]
+
+
+def test_verify_dispatch_exhaustive_not_sealed():
+    """verify_dispatch_exhaustive propagates not-sealed error."""
+    d = Dispatcher("vde_ns")
+
+    class NotSealed:
+        pass
+
+    with pytest.raises(TypeError, match="not a sealed class"):
+        verify_dispatch_exhaustive(d, NotSealed)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+def test_integration_register_verify_unregister_fails():
+    """Full lifecycle: register all handlers, verify passes, unregister one, verify fails."""
+    d = Dispatcher("integration")
+
+    @d.register
+    def on_circle(x: Circle) -> str:
+        return "circle"
+
+    @d.register
+    def on_square(x: Square) -> str:
+        return "square"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    # All covered
+    d.verify_exhaustive(Shape)
+    d.verify_exhaustive_for(Shape)
+    verify_dispatch_exhaustive(d, Shape)
+
+    # Remove one handler — coverage should break
+    d.unregister(on_triangle)
+
+    with pytest.raises(TypeError, match="Triangle"):
+        d.verify_exhaustive(Shape)
+
+    with pytest.raises(TypeError, match="Triangle"):
+        d.verify_exhaustive_for(Shape)
+
+    with pytest.raises(TypeError, match="Triangle"):
+        verify_dispatch_exhaustive(d, Shape)
+
+
+def test_integration_union_covers_multiple_for_param():
+    """A handler with a Union param covers multiple subclasses for that param."""
+    d = Dispatcher("union_integration")
+
+    @d.register
+    def on_circle_or_square(x: Circle | Square) -> str:
+        return "cs"
+
+    @d.register
+    def on_triangle(x: Triangle) -> str:
+        return "triangle"
+
+    d.verify_exhaustive(Shape, param="x")
+    d.verify_exhaustive_for(Shape)
+    d.verify_all_sealed()

--- a/persistent-collections/pyproject.toml
+++ b/persistent-collections/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "persistent-collections"
-version = "0.1.0"
+version = "0.1.1"
 description = "Immutable persistent collections with structural sharing (HAMT-based)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sealed-typing/README.md
+++ b/sealed-typing/README.md
@@ -47,6 +47,7 @@ def area(shape: Shape) -> float:
 | `is_sealed(cls)` | `(type) -> bool` | Check if a class is sealed |
 | `sealed_subclasses(cls)` | `(type) -> frozenset[type]` | Return all registered subclasses |
 | `assert_exhaustive(value, *handlers)` | `(Any, *type) -> None` | Raise `TypeError` if the provided handler classes do not cover the known sealed descendants |
+| `verify_dispatch_exhaustive(dispatcher, sealed_base)` | `(Any, type) -> None` | Verify a live-dispatch `Dispatcher` covers all sealed subclasses (requires live-dispatch) |
 
 ### How `@sealed` works
 

--- a/sealed-typing/pyproject.toml
+++ b/sealed-typing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sealed-typing"
-version = "0.1.0"
+version = "0.1.1"
 description = "Sealed classes for Python with runtime enforcement and exhaustive matching support"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sealed-typing/sealed_typing/__init__.py
+++ b/sealed-typing/sealed_typing/__init__.py
@@ -1,4 +1,16 @@
 """Sealed classes for Python — runtime enforcement + exhaustive matching support."""
-from sealed_typing._sealed import sealed, is_sealed, sealed_subclasses, assert_exhaustive
+from sealed_typing._sealed import (
+    assert_exhaustive,
+    is_sealed,
+    sealed,
+    sealed_subclasses,
+    verify_dispatch_exhaustive,
+)
 
-__all__ = ["sealed", "is_sealed", "sealed_subclasses", "assert_exhaustive"]
+__all__ = [
+    "assert_exhaustive",
+    "is_sealed",
+    "sealed",
+    "sealed_subclasses",
+    "verify_dispatch_exhaustive",
+]

--- a/sealed-typing/sealed_typing/_sealed.py
+++ b/sealed-typing/sealed_typing/_sealed.py
@@ -252,6 +252,32 @@ def sealed_subclasses(cls: type) -> frozenset[type]:
     return frozenset(getattr(cls, '__sealed_subclasses__', set()))
 
 
+def verify_dispatch_exhaustive(dispatcher: Any, sealed_base: type) -> None:
+    """Verify that a live-dispatch Dispatcher covers all sealed subclasses.
+
+    This is a thin convenience wrapper that calls
+    ``dispatcher.verify_exhaustive(sealed_base)``.  It exists so
+    sealed-typing users can verify dispatch coverage without importing
+    live-dispatch directly.
+
+    Args:
+        dispatcher: A ``live_dispatch.Dispatcher`` instance (or any object
+                    that exposes a ``verify_exhaustive`` method).
+        sealed_base: A class decorated with ``@sealed``.
+
+    Raises:
+        TypeError: If *dispatcher* does not have a ``verify_exhaustive``
+                   method, or if the dispatcher does not fully cover all
+                   registered subclasses of *sealed_base*.
+    """
+    if not hasattr(dispatcher, 'verify_exhaustive'):
+        raise TypeError(
+            f"Expected a Dispatcher with a 'verify_exhaustive' method, "
+            f"got {type(dispatcher).__name__!r}"
+        )
+    dispatcher.verify_exhaustive(sealed_base)
+
+
 def assert_exhaustive(value: Any, *handlers: type) -> None:
     """Assert that handlers cover all sealed subclasses.
 

--- a/taskgroup-collect/pyproject.toml
+++ b/taskgroup-collect/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "taskgroup-collect"
-version = "0.1.0"
+version = "0.1.1"
 description = "TaskGroup variant that collects all errors instead of aborting on the first"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -381,3 +381,168 @@ class TestFullPipeline:
             assert state["a"] == 4   # 1 + 3
             assert state["b"] == 6   # 2 + 4
             assert summary == "a=4, b=6"
+
+
+# ---------------------------------------------------------------------------
+# 7. Method combinations + sealed exhaustiveness
+#    CLOS-inspired before/after/around with traced execution and
+#    sealed-type dispatch verification.
+# ---------------------------------------------------------------------------
+
+class TestMethodCombinationsIntegration:
+    """Method combinations compose with sealed types, tracing, and async."""
+
+    def test_before_after_around_with_sealed_dispatch(self):
+        from sealed_typing import sealed
+        from live_dispatch import Dispatcher
+
+        @sealed
+        class Action:
+            pass
+
+        class Build(Action):
+            pass
+
+        class Deploy(Action):
+            pass
+
+        dispatch = Dispatcher("actions")
+        log: list[str] = []
+
+        @dispatch.register
+        def on_build(a: Build) -> str:
+            log.append("primary:build")
+            return "built"
+
+        @dispatch.register
+        def on_deploy(a: Deploy) -> str:
+            log.append("primary:deploy")
+            return "deployed"
+
+        @dispatch.before(Action)
+        def before_action(a: Action) -> None:
+            log.append(f"before:{type(a).__name__}")
+
+        @dispatch.after(Action)
+        def after_action(a: Action) -> None:
+            log.append(f"after:{type(a).__name__}")
+
+        result = dispatch(Build())
+        assert result == "built"
+        assert log == ["before:Build", "primary:build", "after:Build"]
+
+        log.clear()
+        result = dispatch(Deploy())
+        assert result == "deployed"
+        assert log == ["before:Deploy", "primary:deploy", "after:Deploy"]
+
+    def test_traced_dispatch_with_sealed_types(self):
+        from sealed_typing import sealed
+        from live_dispatch import Dispatcher
+
+        @sealed
+        class Shape:
+            pass
+
+        class Circle(Shape):
+            pass
+
+        class Square(Shape):
+            pass
+
+        dispatch = Dispatcher("shapes")
+
+        @dispatch.register
+        def on_circle(s: Circle) -> str:
+            return "circle"
+
+        @dispatch.register
+        def on_square(s: Square) -> str:
+            return "square"
+
+        @dispatch.before(Shape)
+        def pre(s: Shape) -> None:
+            pass
+
+        result, trace = dispatch.call_traced(Circle())
+        assert result == "circle"
+        phases = [e.phase for e in trace]
+        assert "before" in phases
+        assert "primary" in phases
+
+    def test_verify_all_sealed_after_full_registration(self):
+        from sealed_typing import sealed, verify_dispatch_exhaustive
+        from live_dispatch import Dispatcher
+
+        @sealed
+        class Msg:
+            pass
+
+        class Ping(Msg):
+            pass
+
+        class Pong(Msg):
+            pass
+
+        dispatch = Dispatcher("msgs")
+
+        @dispatch.register
+        def on_ping(m: Ping) -> str:
+            return "ping"
+
+        @dispatch.register
+        def on_pong(m: Pong) -> str:
+            return "pong"
+
+        # Both verification paths should pass
+        dispatch.verify_exhaustive(Msg)
+        dispatch.verify_exhaustive_for(Msg)
+        dispatch.verify_all_sealed()
+        verify_dispatch_exhaustive(dispatch, Msg)
+
+    def test_around_advisor_modifies_return(self):
+        from live_dispatch import Dispatcher
+
+        dispatch = Dispatcher("wrap")
+
+        class Item:
+            def __init__(self, val: int):
+                self.val = val
+
+        @dispatch.register
+        def handle(item: Item) -> int:
+            return item.val
+
+        @dispatch.around(Item)
+        def double_result(proceed, item: Item) -> int:
+            return proceed(item) * 2
+
+        assert dispatch(Item(5)) == 10
+
+    @pytest.mark.asyncio
+    async def test_async_combinations(self):
+        from live_dispatch import Dispatcher
+
+        dispatch = Dispatcher("async_combo")
+        log: list[str] = []
+
+        class Request:
+            def __init__(self, path: str):
+                self.path = path
+
+        @dispatch.register
+        async def handle(r: Request) -> str:
+            log.append("primary")
+            return f"ok:{r.path}"
+
+        @dispatch.before(Request)
+        async def auth(r: Request) -> None:
+            log.append("auth")
+
+        @dispatch.after(Request)
+        async def audit(r: Request) -> None:
+            log.append("audit")
+
+        result = await dispatch.call_async(Request("/api"))
+        assert result == "ok:/api"
+        assert log == ["auth", "primary", "audit"]

--- a/with-update/pyproject.toml
+++ b/with-update/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "with-update"
-version = "0.1.0"
+version = "0.1.1"
 description = "Record update syntax for frozen dataclasses and Pydantic models via | operator"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- **CLOS-inspired method combinations** in `live-dispatch`: `:before`, `:after`, `:around` advisor decorators with traced execution (`call_traced`, `call_async_traced`) producing `CombinationTraceEntry` records
- **Strengthened sealed+dispatcher exhaustiveness glue**: `verify_exhaustive(param=)` for per-parameter checks, `verify_exhaustive_for()` for all params referencing a sealed hierarchy, `verify_all_sealed()` for auto-discovery, plus `verify_dispatch_exhaustive()` convenience in sealed-typing
- **Version bump to 0.1.1** across all 8 packages with CHANGELOG update
- Updated READMEs for live-dispatch and sealed-typing with new API documentation
- 5 new cross-package integration tests covering combinations + sealed dispatch

## Test plan

- [x] 1248 tests pass (101 new: 75 combinations + 26 sealed glue + 5 integration)
- [x] mypy strict passes on all source and test files (62 files, 0 issues)
- [x] All 8 pyproject.toml files at version 0.1.1
- [x] Pre-commit hooks pass (ruff, syntax, secrets scan)
- [x] README API tables verified against actual exports