### PR TITLE
feat(release): prepare public docs and security checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Docs
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "RELEASING.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5.0.0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install docs dependencies
+        run: python -m pip install -r docs/requirements.txt
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build docs site
+        run: python -m mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install release tooling
-        run: uv pip install --system build twine
+        run: uv pip install --system --upgrade build twine pkginfo
 
       - name: Build distributions
         run: cd ${{ matrix.package-dir }} && python -m build .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,27 @@ jobs:
       - name: Mypy
         run: make typecheck
 
+  security:
+    runs-on: ubuntu-latest
+    name: Security audit
+
+    steps:
+      - uses: actions/checkout@v5.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install security tooling
+        run: uv pip install --system bandit pip-audit
+
+      - name: Run security checks
+        run: make security
+
   deprecationcheck:
     runs-on: ubuntu-latest
     name: Deprecation check

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.egg
 dist/
 build/
+site/
 .eggs/
 *.so
 .pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.1.1 - 2026-04-05
+## 0.1.0 - 2026-04-05
+
+Initial monorepo release for the hulista package family.
 
 ### Added
 
@@ -11,13 +13,6 @@ All notable changes to this project will be documented in this file.
 - `persistent-collections`: `freeze()` and `thaw()` recursive converters between plain Python dicts/lists and PersistentMap/PersistentVector, enabling gradual migration of mutable data structures.
 - `live-dispatch`: CLOS-inspired method combinations (`:before`, `:after`, `:around`) with traced execution support, plus strengthened sealed-type exhaustiveness verification with per-parameter and auto-discovery modes.
 - `sealed-typing`: `verify_dispatch_exhaustive()` convenience function for verifying live-dispatch handler coverage of sealed hierarchies.
-
-## 0.1.0 - 2026-04-05
-
-Initial monorepo release for the hulista package family.
-
-### Added
-
 - `persistent-collections`: `PersistentMap` and `PersistentVector` with structural sharing, transient builders, structural diffing, and hashable immutable collections.
 - `sealed-typing`: `@sealed`, sealed subclass tracking, and runtime exhaustiveness helpers for `match`/`case` workflows.
 - `asyncio-actors`: OTP-inspired actor primitives with bounded inboxes, supervision trees, selective receive, circuit breakers, and async-sync bridge support.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,12 @@ Run all commands from the repo root.
 - `make test`: run the full monorepo test suite.
 - `make coverage`: run the full suite with coverage gates. This must keep every package at `>=95%` line coverage and `>=90%` branch coverage.
 - `make typecheck`: run the repo mypy gate (strict on sources via `mypy.ini`, lenient on tests/benchmarks via `mypy-tests.ini`).
+- `make security`: run Bandit on shipped source packages and `pip-audit` on the repo's third-party dependency surface.
 - `make deprecationcheck`: run the repo test/build paths with deprecation warnings promoted to errors.
 - `make bench`: run the benchmark suite and compare results against checked-in budgets.
 - `make build`: build sdists and wheels for all packages.
+- `make docs-build`: build the public docs site locally (`python -m pip install -r docs/requirements.txt` first).
+- `make docs-serve`: run the docs site locally with live reload.
 
 The Makefile defaults to `python3`. Override with `make test PYTHON=/path/to/python` to use a specific interpreter.
 
@@ -20,6 +23,7 @@ The GitHub Actions workflow has six main jobs:
 - `test`: package unit tests plus the top-level integration suite across the active Python matrix.
 - `coverage`: the enforced coverage gate on Python 3.11.
 - `typecheck`: the enforced mypy gate on Python 3.11 (strict for library sources, lenient for tests/benchmarks).
+- `security`: the enforced source-code and dependency audit gate on Python 3.11.
 - `deprecationcheck`: the enforced warnings-as-errors gate for repo tests and package builds on Python 3.11.
 - `build`: wheel and sdist smoke builds for every package.
 - `benchmark`: benchmark checks on Python 3.11.
@@ -40,3 +44,13 @@ To promote a disabled error code: remove it from `mypy-tests.ini`, run `make typ
 All packages currently use `setuptools.build_meta`. Keep packaging changes consistent across packages unless there is a package-specific reason not to.
 
 Source distributions intentionally exclude repo test suites and benchmark fixtures. Validate packaging changes with `make build` before merging.
+
+## Docs
+
+The public docs site is built with MkDocs from [`docs/`](docs/). Install the docs toolchain with:
+
+```bash
+python -m pip install -r docs/requirements.txt
+```
+
+Then use `make docs-build` for a strict production build or `make docs-serve` while editing.

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,19 @@ BUILD_PACKAGES := \
 	taskgroup-collect \
 	with-update \
 	hulista
+SECURITY_SOURCE_DIRS := \
+	asyncio-actors/asyncio_actors \
+	fp-combinators/fp_combinators \
+	hulista/hulista \
+	live-dispatch/live_dispatch \
+	persistent-collections/persistent_collections \
+	sealed-typing/sealed_typing \
+	taskgroup-collect/taskgroup_collect \
+	with-update/with_update
 PYTEST_DEPRECATION_FLAGS := -W error::DeprecationWarning -W error::PendingDeprecationWarning
 BUILD_DEPRECATION_FLAGS := -W error::DeprecationWarning -W error::PendingDeprecationWarning -W error::UserWarning:setuptools
 
-.PHONY: test coverage typecheck bench build deprecationcheck
+.PHONY: test coverage typecheck bench build deprecationcheck security docs-build docs-serve
 
 test:
 	PYTHONPATH="$(PYTHONPATH)" $(PYTHON) -m pytest -p no:pytest_monitor $(PACKAGE_TESTS) -q
@@ -53,3 +62,16 @@ deprecationcheck:
 	for pkg in $(BUILD_PACKAGES); do \
 		(cd $$pkg && $(PYTHON) $(BUILD_DEPRECATION_FLAGS) -m build .); \
 	done
+
+security:
+	$(PYTHON) -m bandit -q -r $(SECURITY_SOURCE_DIRS)
+	tmpfile="$$(mktemp)"; \
+	$(PYTHON) scripts/write_security_requirements.py "$$tmpfile"; \
+	$(PYTHON) -m pip_audit -r "$$tmpfile"; \
+	rm -f "$$tmpfile"
+
+docs-build:
+	$(PYTHON) -m mkdocs build --strict
+
+docs-serve:
+	$(PYTHON) -m mkdocs serve

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Functional programming and structured-concurrency building blocks for Python, born from real friction points in production agent orchestration.
 
+Public docs: <https://rahulrajaram.github.io/hulista/>
+
 ## Packages
 
 | Package | Description | Python |
@@ -215,7 +217,17 @@ make typecheck
 # Run warnings-as-errors and packaging checks
 make deprecationcheck
 make build
+
+# Build or preview the public docs site
+python -m pip install -r docs/requirements.txt
+make docs-build
 ```
+
+## Release
+
+- Public docs are built from [`docs/`](docs/) with MkDocs and deployed by [`.github/workflows/docs.yml`](.github/workflows/docs.yml).
+- PyPI publishing is driven by [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
+- The release checklist lives in [`RELEASING.md`](RELEASING.md).
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,7 +73,7 @@ The production path is tag-driven. Pushing a tag that matches `v*` will publish 
 Recommended sequence:
 
 1. Merge the release commit to `master`.
-2. Create an annotated tag such as `v0.1.1`.
+2. Create an annotated tag such as `v0.1.0`.
 3. Push the tag.
 4. Watch [`.github/workflows/publish.yml`](.github/workflows/publish.yml) complete for every package.
 5. Verify the live pages on PyPI and the docs site.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,89 @@
+# Releasing hulista
+
+This repository already has the two core automation pieces needed for a public release:
+
+- GitHub Pages deployment for docs via [`.github/workflows/docs.yml`](.github/workflows/docs.yml)
+- Trusted Publishing to PyPI and TestPyPI via [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
+
+## One-time repository setup
+
+Before the first public release, confirm these settings in GitHub and PyPI:
+
+1. Enable GitHub Pages for this repository and allow GitHub Actions to deploy it.
+2. Create `hulista` and each leaf package on PyPI and TestPyPI if you want to reserve the names ahead of time.
+3. Configure PyPI Trusted Publishing for this repository and the `pypi` environment.
+4. Configure TestPyPI Trusted Publishing for this repository and the `testpypi` environment.
+5. Protect the `pypi` environment if you want a manual approval gate before production publishing.
+
+## Pre-release checklist
+
+1. Make sure `CHANGELOG.md` reflects the release contents.
+2. Confirm package versions are aligned across `pyproject.toml` files and any exported `__version__` constants.
+3. Build and verify the docs locally:
+
+```bash
+python -m pip install -r docs/requirements.txt
+make docs-build
+```
+
+4. Run the release gates:
+
+```bash
+make test
+make coverage
+make typecheck
+make security
+make deprecationcheck
+make build
+```
+
+5. Sanity-check the umbrella package metadata:
+
+```bash
+python -m pip install -U build twine pkginfo
+cd hulista
+python -m build .
+python -m twine check dist/*
+```
+
+## TestPyPI dry run
+
+Use the existing `Publish` workflow before the first real release and before any packaging-heavy change:
+
+1. Open GitHub Actions.
+2. Run `Publish`.
+3. Choose `repository = testpypi`.
+4. Set `ref` to the branch, commit SHA, or release candidate tag you want to validate.
+5. Wait for all matrix jobs to finish.
+
+Then validate installs from TestPyPI in a clean virtual environment. Example:
+
+```bash
+python -m venv .venv-testpypi
+source .venv-testpypi/bin/activate
+python -m pip install -U pip
+python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple hulista
+python -c "import hulista; print(hulista.__version__)"
+```
+
+## Production release
+
+The production path is tag-driven. Pushing a tag that matches `v*` will publish every package in the monorepo.
+
+Recommended sequence:
+
+1. Merge the release commit to `master`.
+2. Create an annotated tag such as `v0.1.1`.
+3. Push the tag.
+4. Watch [`.github/workflows/publish.yml`](.github/workflows/publish.yml) complete for every package.
+5. Verify the live pages on PyPI and the docs site.
+
+## Release model
+
+This repo is currently set up for coordinated releases:
+
+- one changelog
+- one release tag namespace
+- one publish workflow matrix for all packages
+
+That is a good fit while the package family is still moving together. If you later want independent release cadences, the publish workflow and tag strategy should be split per package.

--- a/asyncio-actors/asyncio_actors/__init__.py
+++ b/asyncio-actors/asyncio_actors/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "DispatchActor",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/asyncio-actors/asyncio_actors/__init__.py
+++ b/asyncio-actors/asyncio_actors/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "DispatchActor",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.0"

--- a/asyncio-actors/asyncio_actors/dispatch_actor.py
+++ b/asyncio-actors/asyncio_actors/dispatch_actor.py
@@ -4,12 +4,15 @@
 # them to wrappers) so that Dispatcher.register() can call get_type_hints()
 # correctly.
 
+import ast
 import inspect
 import sys
 import typing
 from typing import Any, Callable, ClassVar
 
 from asyncio_actors.actor import Actor
+
+_UNRESOLVED = object()
 
 
 def _make_dispatcher(name: str) -> Any:
@@ -54,22 +57,131 @@ def _resolve_annotations_at_decoration(fn: Callable[..., Any]) -> dict[str, Any]
         hints = typing.get_type_hints(fn, globalns=merged_globals, localns=localns)
     except (NameError, AttributeError, TypeError):
         # Fall back: use the raw annotation dict (values may be strings).
-        # We'll convert them best-effort.
+        # Resolve only a narrow safe subset instead of executing annotation
+        # expressions. Dispatch handlers only need runtime type objects.
         hints = {}
         raw = getattr(fn, "__annotations__", {})
         for k, v in raw.items():
             if k == "return":
                 continue
             if isinstance(v, str):
-                try:
-                    hints[k] = eval(v, merged_globals, localns)  # noqa: S307
-                except Exception:
-                    pass  # annotation stays unresolved; skip this param
+                resolved = _resolve_string_annotation(v, merged_globals, localns)
+                if resolved is not _UNRESOLVED:
+                    hints[k] = resolved
             else:
                 hints[k] = v
         return hints
 
     return {k: v for k, v in hints.items() if k != "return"}
+
+
+def _resolve_string_annotation(
+    annotation: str,
+    globalns: dict[str, Any],
+    localns: dict[str, Any],
+) -> Any:
+    """Resolve a safe subset of string annotations without using eval().
+
+    Supported forms:
+    - ``Name``
+    - dotted attribute chains such as ``module.Type`` or ``Outer.Inner``
+    - ``A | B`` unions
+    - ``typing.Union[A, B]`` and ``typing.Optional[A]``
+    """
+    try:
+        node = ast.parse(annotation, mode="eval").body
+    except SyntaxError:
+        return _UNRESOLVED
+    return _resolve_annotation_node(node, globalns, localns)
+
+
+def _resolve_annotation_node(
+    node: ast.AST,
+    globalns: dict[str, Any],
+    localns: dict[str, Any],
+) -> Any:
+    if isinstance(node, ast.Name):
+        return _lookup_annotation_name(node.id, globalns, localns)
+
+    if isinstance(node, ast.Attribute):
+        base = _resolve_annotation_node(node.value, globalns, localns)
+        if base is _UNRESOLVED:
+            return _UNRESOLVED
+        return getattr(base, node.attr, _UNRESOLVED)
+
+    if isinstance(node, ast.Constant) and node.value is None:
+        return type(None)
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _resolve_annotation_node(node.left, globalns, localns)
+        right = _resolve_annotation_node(node.right, globalns, localns)
+        if left is _UNRESOLVED or right is _UNRESOLVED:
+            return _UNRESOLVED
+        try:
+            return left | right
+        except TypeError:
+            return _UNRESOLVED
+
+    if isinstance(node, ast.Subscript):
+        base = _resolve_annotation_node(node.value, globalns, localns)
+        if base is _UNRESOLVED:
+            return _UNRESOLVED
+        args = _resolve_annotation_subscript_args(node.slice, globalns, localns)
+        if args is _UNRESOLVED:
+            return _UNRESOLVED
+        if base is typing.Union:
+            try:
+                result = args[0]
+                for part in args[1:]:
+                    result = result | part
+                return result
+            except TypeError:
+                return _UNRESOLVED
+        if base is typing.Optional and len(args) == 1:
+            try:
+                return args[0] | type(None)
+            except TypeError:
+                return _UNRESOLVED
+        return _UNRESOLVED
+
+    return _UNRESOLVED
+
+
+def _resolve_annotation_subscript_args(
+    node: ast.AST,
+    globalns: dict[str, Any],
+    localns: dict[str, Any],
+) -> tuple[Any, ...] | object:
+    if isinstance(node, ast.Tuple):
+        resolved = tuple(
+            _resolve_annotation_node(item, globalns, localns)
+            for item in node.elts
+        )
+        if any(item is _UNRESOLVED for item in resolved):
+            return _UNRESOLVED
+        return resolved
+
+    resolved = _resolve_annotation_node(node, globalns, localns)
+    if resolved is _UNRESOLVED:
+        return _UNRESOLVED
+    return (resolved,)
+
+
+def _lookup_annotation_name(
+    name: str,
+    globalns: dict[str, Any],
+    localns: dict[str, Any],
+) -> Any:
+    if name == "None":
+        return type(None)
+    if name in localns:
+        return localns[name]
+    if name in globalns:
+        return globalns[name]
+    typing_value = getattr(typing, name, _UNRESOLVED)
+    if typing_value is not _UNRESOLVED:
+        return typing_value
+    return _UNRESOLVED
 
 
 class _HandleMarker:

--- a/asyncio-actors/asyncio_actors/dispatch_actor.py
+++ b/asyncio-actors/asyncio_actors/dispatch_actor.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, ClassVar
 
 from asyncio_actors.actor import Actor
 
-_UNRESOLVED = object()
+_UNRESOLVED: object = object()
 
 
 def _make_dispatcher(name: str) -> Any:
@@ -129,17 +129,18 @@ def _resolve_annotation_node(
         args = _resolve_annotation_subscript_args(node.slice, globalns, localns)
         if args is _UNRESOLVED:
             return _UNRESOLVED
+        resolved_args = typing.cast(tuple[Any, ...], args)
         if base is typing.Union:
             try:
-                result = args[0]
-                for part in args[1:]:
+                result = resolved_args[0]
+                for part in resolved_args[1:]:
                     result = result | part
                 return result
             except TypeError:
                 return _UNRESOLVED
-        if base is typing.Optional and len(args) == 1:
+        if base is typing.Optional and len(resolved_args) == 1:
             try:
-                return args[0] | type(None)
+                return resolved_args[0] | type(None)
             except TypeError:
                 return _UNRESOLVED
         return _UNRESOLVED
@@ -151,7 +152,7 @@ def _resolve_annotation_subscript_args(
     node: ast.AST,
     globalns: dict[str, Any],
     localns: dict[str, Any],
-) -> tuple[Any, ...] | object:
+) -> Any:
     if isinstance(node, ast.Tuple):
         resolved = tuple(
             _resolve_annotation_node(item, globalns, localns)

--- a/asyncio-actors/pyproject.toml
+++ b/asyncio-actors/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/asyncio-actors/pyproject.toml
+++ b/asyncio-actors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asyncio-actors"
-version = "0.1.1"
+version = "0.1.0"
 description = "OTP-inspired actor primitives for Python's asyncio with supervision trees, bounded inboxes, and async-sync bridge"
 readme = "README.md"
 license = "MIT"

--- a/asyncio-actors/tests/test_dispatch_actor.py
+++ b/asyncio-actors/tests/test_dispatch_actor.py
@@ -2,9 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
-import unittest.mock
 import pytest
 
 from asyncio_actors.dispatch_actor import DispatchActor
@@ -217,6 +214,39 @@ async def test_default_on_unhandled_raises_type_error():
         ref = await system.spawn(StrictActor)
         with pytest.raises(TypeError):
             await ref.ask(Unknown())
+
+
+@pytest.mark.asyncio
+async def test_local_scope_annotations_resolve_without_eval():
+    class LocalMsg:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    class LocalActor(DispatchActor):
+        @DispatchActor.handle
+        async def on_local(self, msg: LocalMsg) -> str:
+            return msg.value.upper()
+
+    async with ActorSystem() as system:
+        ref = await system.spawn(LocalActor)
+        assert await ref.ask(LocalMsg("ok")) == "OK"
+
+
+def test_unsafe_annotation_expression_is_not_executed(monkeypatch):
+    from asyncio_actors.dispatch_actor import _UNRESOLVED, _resolve_string_annotation
+    import os
+
+    calls: list[str] = []
+
+    def fake_system(command: str) -> int:
+        calls.append(command)
+        return 0
+
+    monkeypatch.setattr(os, "system", fake_system)
+
+    resolved = _resolve_string_annotation("os.system('echo bandit')", {"os": os}, {})
+    assert resolved is _UNRESOLVED
+    assert calls == []
 
 
 # ===========================================================================

--- a/asyncio-actors/tests/test_dispatch_actor.py
+++ b/asyncio-actors/tests/test_dispatch_actor.py
@@ -2,9 +2,23 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
+import inspect
+import typing
 import pytest
 
-from asyncio_actors.dispatch_actor import DispatchActor
+import asyncio_actors.dispatch_actor as dispatch_actor_module
+from asyncio_actors.dispatch_actor import (
+    _HandleMarker,
+    _UNRESOLVED,
+    _lookup_annotation_name,
+    _make_dispatcher,
+    _make_handler_wrapper,
+    _resolve_annotation_subscript_args,
+    _resolve_annotations_at_decoration,
+    _resolve_string_annotation,
+    DispatchActor,
+)
 from asyncio_actors.system import ActorSystem
 
 
@@ -233,7 +247,6 @@ async def test_local_scope_annotations_resolve_without_eval():
 
 
 def test_unsafe_annotation_expression_is_not_executed(monkeypatch):
-    from asyncio_actors.dispatch_actor import _UNRESOLVED, _resolve_string_annotation
     import os
 
     calls: list[str] = []
@@ -247,6 +260,225 @@ def test_unsafe_annotation_expression_is_not_executed(monkeypatch):
     resolved = _resolve_string_annotation("os.system('echo bandit')", {"os": os}, {})
     assert resolved is _UNRESOLVED
     assert calls == []
+
+
+def test_make_dispatcher_returns_dispatcher_instance():
+    dispatcher = _make_dispatcher("test-dispatcher")
+    assert dispatcher is not None
+    assert type(dispatcher).__name__ == "Dispatcher"
+
+
+def test_make_dispatcher_returns_none_when_live_dispatch_is_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "live_dispatch._dispatcher":
+            raise ImportError("simulated")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert _make_dispatcher("missing") is None
+
+
+def test_lookup_annotation_name_prefers_local_then_global_then_typing():
+    local_value = object()
+    global_value = object()
+
+    assert _lookup_annotation_name("None", {}, {}) is type(None)
+    assert (
+        _lookup_annotation_name("Thing", {"Thing": global_value}, {"Thing": local_value})
+        is local_value
+    )
+    assert _lookup_annotation_name("Thing", {"Thing": global_value}, {}) is global_value
+    assert _lookup_annotation_name("Optional", {}, {}) is typing.Optional
+    assert _lookup_annotation_name("Missing", {}, {}) is _UNRESOLVED
+
+
+def test_resolve_string_annotation_handles_supported_forms():
+    namespace = {
+        "Outer": type("Outer", (), {"Inner": Ping}),
+        "Ping": Ping,
+        "Pong": Pong,
+        "int_value": 1,
+        "typing": typing,
+    }
+
+    assert _resolve_string_annotation("Ping", {"Ping": Ping}, {}) is Ping
+    assert _resolve_string_annotation("Outer.Inner", namespace, {}) is Ping
+    assert _resolve_string_annotation("None", {}, {}) is type(None)
+    assert _resolve_string_annotation("Ping | Pong", {"Ping": Ping, "Pong": Pong}, {}) == (
+        Ping | Pong
+    )
+    assert _resolve_string_annotation("typing.Union[Ping, Pong]", namespace, {}) == (
+        Ping | Pong
+    )
+    assert _resolve_string_annotation("typing.Optional[Ping]", {"Ping": Ping, "typing": typing}, {}) == (
+        Ping | type(None)
+    )
+    assert _resolve_string_annotation("not valid[", {}, {}) is _UNRESOLVED
+    assert _resolve_string_annotation("Missing.Inner", {}, {}) is _UNRESOLVED
+    assert _resolve_string_annotation("typing.Union[Ping, Missing]", {"Ping": Ping}, {}) is _UNRESOLVED
+    assert _resolve_string_annotation("typing.Optional[int_value]", namespace, {}) is _UNRESOLVED
+
+
+def test_resolve_annotation_subscript_args_handles_tuple_and_single_values():
+    tuple_node = inspect.cleandoc(
+        """
+        typing.Union[Ping, Pong]
+        """
+    )
+    parsed = dispatch_actor_module.ast.parse(tuple_node, mode="eval").body
+    assert isinstance(parsed, dispatch_actor_module.ast.Subscript)
+    assert _resolve_annotation_subscript_args(parsed.slice, {"Ping": Ping, "Pong": Pong}, {}) == (
+        Ping,
+        Pong,
+    )
+
+    single_node = dispatch_actor_module.ast.parse("Ping", mode="eval").body
+    assert _resolve_annotation_subscript_args(single_node, {"Ping": Ping}, {}) == (Ping,)
+
+    unresolved_tuple = dispatch_actor_module.ast.parse(
+        "typing.Union[Ping, Missing]", mode="eval"
+    ).body
+    assert isinstance(unresolved_tuple, dispatch_actor_module.ast.Subscript)
+    assert _resolve_annotation_subscript_args(unresolved_tuple.slice, {"Ping": Ping}, {}) is _UNRESOLVED
+
+    unresolved_single = dispatch_actor_module.ast.parse("Missing", mode="eval").body
+    assert _resolve_annotation_subscript_args(unresolved_single, {}, {}) is _UNRESOLVED
+
+
+def test_resolve_annotations_at_decoration_falls_back_without_eval(monkeypatch):
+    monkeypatch.setattr(typing, "get_type_hints", lambda *args, **kwargs: (_ for _ in ()).throw(NameError("nope")))
+
+    class LocalOnly:
+        pass
+
+    class FakeFrame:
+        def __init__(self, locals_dict: dict[str, object]) -> None:
+            self.f_locals = locals_dict
+
+    def fake_getframe(depth: int):
+        if depth == 1:
+            return FakeFrame({"LocalOnly": LocalOnly, "int": int})
+        raise ValueError("done")
+
+    monkeypatch.setattr(dispatch_actor_module.sys, "_getframe", fake_getframe)
+
+    def handler(msg, raw, missing):
+        return msg
+
+    handler.__annotations__ = {
+        "msg": "LocalOnly",
+        "raw": "int",
+        "missing": "Missing",
+        "return": "LocalOnly",
+    }
+
+    hints = _resolve_annotations_at_decoration(handler)
+    assert hints == {"msg": LocalOnly, "raw": int}
+
+
+def test_resolve_annotations_at_decoration_uses_get_type_hints_when_available():
+    class LocalOnly:
+        pass
+
+    def handler(msg: LocalOnly) -> LocalOnly:
+        return msg
+
+    hints = _resolve_annotations_at_decoration(handler)
+    assert hints == {"msg": LocalOnly}
+
+
+def test_handle_marker_descriptor_and_wrapper_behaviour():
+    class MarkerActor:
+        async def handle_ping(self, msg: Ping) -> str:
+            return msg.value
+
+    marker = _HandleMarker(MarkerActor.handle_ping)
+    actor = MarkerActor()
+
+    assert marker.__get__(None, MarkerActor) is marker
+    bound = marker.__get__(actor, MarkerActor)
+    assert inspect.ismethod(bound)
+
+
+@pytest.mark.asyncio
+async def test_make_handler_wrapper_preserves_signature_and_annotations():
+    class WrapperActor:
+        async def handle_ping(self, msg: Ping, suffix: str = "!") -> str:
+            return f"{msg.value}{suffix}"
+
+    wrapper = _make_handler_wrapper(WrapperActor.handle_ping, {"msg": Ping, "suffix": str})
+    actor = WrapperActor()
+
+    assert wrapper.__annotations__ == {"self": object, "msg": Ping, "suffix": str}
+    assert inspect.signature(wrapper) == inspect.signature(WrapperActor.handle_ping)
+    assert wrapper.__module__ == "asyncio_actors.dispatch_actor"
+    assert await wrapper(actor, Ping("ok"), suffix="?") == "ok?"
+
+
+@pytest.mark.asyncio
+async def test_on_message_falls_back_when_dispatcher_missing(monkeypatch):
+    monkeypatch.setattr(dispatch_actor_module, "_make_dispatcher", lambda name: None)
+
+    class MissingDispatcherActor(DispatchActor):
+        async def on_unhandled(self, message) -> str:
+            return f"missing:{message}"
+
+    actor = MissingDispatcherActor()
+    assert MissingDispatcherActor._dispatcher is None
+    assert await actor.on_message("payload") == "missing:payload"
+
+
+@pytest.mark.asyncio
+async def test_on_message_falls_back_when_dispatcher_raises_type_error():
+    class RaisingDispatcher:
+        async def call_async(self, actor, message):
+            raise TypeError("no match")
+
+    class RaisingActor(DispatchActor):
+        async def on_unhandled(self, message) -> str:
+            return f"fallback:{message}"
+
+    RaisingActor._dispatcher = RaisingDispatcher()
+    actor = RaisingActor()
+    assert await actor.on_message("payload") == "fallback:payload"
+
+
+def test_init_subclass_registers_handlers_from_base_classes():
+    class TrackingDispatcher:
+        def __init__(self):
+            self.registered: list[typing.Callable[..., typing.Any]] = []
+            self.verified = None
+
+        def register(self, fn):
+            self.registered.append(fn)
+
+        def verify_exhaustive(self, mt):
+            self.verified = mt
+
+    dispatcher = TrackingDispatcher()
+    original = dispatch_actor_module._make_dispatcher
+    dispatch_actor_module._make_dispatcher = lambda name: dispatcher
+    try:
+        class BaseTracked(DispatchActor):
+            @DispatchActor.handle
+            async def on_ping(self, msg: Ping) -> str:
+                return "ping"
+
+        class DerivedTracked(BaseTracked):
+            message_type = type("NotSealed", (), {"__sealed__": False})
+
+            @DispatchActor.handle
+            async def on_pong(self, msg: Pong) -> str:
+                return "pong"
+
+    finally:
+        dispatch_actor_module._make_dispatcher = original
+
+    names = [fn.__name__ for fn in dispatcher.registered]
+    assert names == ["on_ping", "on_ping", "on_pong"]
+    assert dispatcher.verified is None
 
 
 # ===========================================================================

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,64 @@
+# Getting Started
+
+## Install choices
+
+Use the umbrella package when you want the full stack:
+
+```bash
+pip install hulista
+```
+
+Use individual packages when you only need a subset:
+
+```bash
+pip install persistent-collections live-dispatch
+```
+
+## What `hulista` re-exports
+
+The umbrella package re-exports a curated subset of the most common APIs:
+
+- `PersistentMap`, `PersistentVector`, `TransientMap`
+- `Result`, `Ok`, `Err`, `pipe`, `async_pipe`, `async_try_pipe`
+- `Actor`, `ActorRef`, `ActorSystem`
+- `Dispatcher`
+- `sealed`, `sealed_subclasses`
+- `CollectorTaskGroup`
+- `updatable`, `with_update`
+
+## First composition
+
+```python
+import hulista
+
+
+store = hulista.PersistentMap().set("count", 1)
+updated = store.set("count", store["count"] + 1)
+
+value = hulista.pipe(
+    updated,
+    lambda pm: pm["count"],
+    lambda count: count * 10,
+)
+
+assert value == 20
+```
+
+## When to pick individual packages
+
+Choose a focused package instead of `hulista` if:
+
+- your library only needs one concept and you want minimal dependency surface
+- you need Python 3.10 support for a package that does not require 3.11
+- you want to keep your public API explicit about which hulista primitive you depend on
+
+The umbrella package itself requires Python 3.11 because some bundled packages do.
+
+## Local docs workflow
+
+```bash
+python -m pip install -r docs/requirements.txt
+make docs-serve
+```
+
+Use `make docs-build` before publishing docs changes to catch broken links or invalid markdown extensions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,114 @@
+# hulista
+
+<div class="hero">
+  <p class="hero-kicker">Python building blocks for immutable state, typed control flow, and structured concurrency.</p>
+  <h1>Functional, immutable, concurrent Python that composes.</h1>
+  <p class="hero-copy">
+    hulista packages fill real stdlib gaps: persistent collections, sealed hierarchies,
+    collect-all task groups, runtime dispatch, actor supervision, and ergonomic immutable updates.
+  </p>
+  <div class="hero-actions">
+    <a class="md-button md-button--primary" href="getting-started/">Get started</a>
+    <a class="md-button" href="packages/">Explore packages</a>
+  </div>
+</div>
+
+## Why hulista?
+
+- Persistent immutable collections are still awkward in Python when state changes frequently.
+- `asyncio` gives you tasks, but not OTP-style supervision or collect-all structured concurrency.
+- Python has excellent typing primitives, but not sealed class workflows for exhaustive branching.
+- Runtime-extensible dispatch and record-update ergonomics are common needs in event-driven systems.
+
+hulista takes those rough edges seriously and keeps the pieces small enough to adopt independently.
+
+## Install
+
+Install the umbrella package:
+
+```bash
+pip install hulista
+```
+
+Or install only the pieces you need:
+
+```bash
+pip install persistent-collections sealed-typing taskgroup-collect
+```
+
+## Quick example
+
+```python
+from dataclasses import dataclass, field
+
+import hulista
+
+
+@hulista.sealed
+class Command:
+    pass
+
+
+class Rename(Command):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+@hulista.updatable
+@dataclass(frozen=True)
+class State:
+    name: str = "guest"
+    audit: hulista.PersistentVector = field(default_factory=hulista.PersistentVector)
+
+
+def apply(state: State, command: Command) -> State:
+    match command:
+        case Rename(value=value):
+            return state | {
+                "name": value,
+                "audit": state.audit.append(f"rename:{value}"),
+            }
+
+
+next_state = apply(State(), Rename("rahul"))
+assert next_state.name == "rahul"
+```
+
+## Package family
+
+<div class="package-grid">
+  <a class="package-card" href="packages/#persistent-collections">
+    <strong>persistent-collections</strong>
+    <span>Immutable maps and vectors with structural sharing.</span>
+  </a>
+  <a class="package-card" href="packages/#sealed-typing">
+    <strong>sealed-typing</strong>
+    <span>Closed hierarchies for exhaustive branching and dispatch coverage.</span>
+  </a>
+  <a class="package-card" href="packages/#asyncio-actors">
+    <strong>asyncio-actors</strong>
+    <span>Supervised async actors, bounded inboxes, and bridges.</span>
+  </a>
+  <a class="package-card" href="packages/#taskgroup-collect">
+    <strong>taskgroup-collect</strong>
+    <span>Structured concurrency that gathers all results and failures.</span>
+  </a>
+  <a class="package-card" href="packages/#fp-combinators">
+    <strong>fp-combinators</strong>
+    <span>Small pipeline, Result, and traversal helpers for clearer control flow.</span>
+  </a>
+  <a class="package-card" href="packages/#live-dispatch">
+    <strong>live-dispatch</strong>
+    <span>Dynamic multiple dispatch with rollback and async support.</span>
+  </a>
+  <a class="package-card" href="packages/#with-update">
+    <strong>with-update</strong>
+    <span>Record-update syntax for frozen dataclasses and Pydantic models.</span>
+  </a>
+</div>
+
+## Release surface
+
+- The public docs site is published from this `docs/` directory with GitHub Pages.
+- PyPI publishing is automated by GitHub Actions with Trusted Publishing.
+- The release checklist lives in [`RELEASING.md`](https://github.com/rahulrajaram/hulista/blob/master/RELEASING.md).

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,107 @@
+# Package Guide
+
+## persistent-collections
+
+- Import: `persistent_collections`
+- Python: `>=3.10`
+- Best for: immutable state, structural sharing, efficient diffs, transient batch updates
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/persistent-collections>
+
+Key types:
+
+- `PersistentMap`
+- `PersistentVector`
+- `TransientMap`
+- `diff()`
+- `freeze()` / `thaw()`
+
+## sealed-typing
+
+- Import: `sealed_typing`
+- Python: `>=3.10`
+- Best for: closed hierarchies, exhaustiveness checks, cleaner `match` workflows
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/sealed-typing>
+
+Key APIs:
+
+- `@sealed`
+- `sealed_subclasses()`
+- `verify_dispatch_exhaustive()`
+
+## asyncio-actors
+
+- Import: `asyncio_actors`
+- Python: `>=3.11`
+- Best for: supervised worker trees, inbox policies, ask/send patterns, async-sync bridges
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/asyncio-actors>
+
+Key types:
+
+- `Actor`
+- `ActorRef`
+- `ActorSystem`
+- `Supervisor`
+- `ChildSpec`
+- `CircuitBreaker`
+
+## taskgroup-collect
+
+- Import: `taskgroup_collect`
+- Python: `>=3.11`
+- Best for: fan-out work that must collect all outcomes instead of failing fast
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/taskgroup-collect>
+
+Key APIs:
+
+- `CollectorTaskGroup`
+- `collect_results()`
+- `outcome_to_result()`
+- `outcomes_to_results()`
+
+## fp-combinators
+
+- Import: `fp_combinators`
+- Python: `>=3.10`
+- Best for: value pipelines, async composition, typed Result flows
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/fp-combinators>
+
+Key APIs:
+
+- `pipe()`
+- `compose()`
+- `async_pipe()`
+- `Result`, `Ok`, `Err`
+- `try_pipe()`
+- `traverse_all()`
+- `async_traverse_all()`
+
+## live-dispatch
+
+- Import: `live_dispatch`
+- Python: `>=3.10`
+- Best for: runtime-extensible handler registration, type and predicate dispatch, reversible experimentation
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/live-dispatch>
+
+Key APIs:
+
+- `Dispatcher`
+- `call_async()`
+- `verify_exhaustive()`
+- `versioned()`
+
+## with-update
+
+- Import: `with_update`
+- Python: `>=3.10`
+- Best for: ergonomic immutable updates on frozen dataclasses and Pydantic models
+- Source: <https://github.com/rahulrajaram/hulista/tree/master/with-update>
+
+Key APIs:
+
+- `@updatable`
+- `with_update()`
+- `|`
+
+## Choosing the umbrella package
+
+Install `hulista` when you want one dependency and one docs entry point. Install individual packages when you want finer Python-version control or a narrower transitive dependency surface.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,35 @@
+# Releasing
+
+This project already has automated publishing wired up in GitHub Actions. The goal is to make releases repeatable and low-drama.
+
+## Docs publishing
+
+The public documentation site is built from this `docs/` directory and deployed by the `Docs` workflow to GitHub Pages.
+
+Before merging docs changes:
+
+```bash
+python -m pip install -r docs/requirements.txt
+make docs-build
+```
+
+## Package publishing
+
+The PyPI workflow publishes every package in the monorepo, including `hulista`.
+
+Important implication:
+
+- A release tag is a coordinated monorepo release, not a one-package release.
+
+## Recommended release flow
+
+1. Update package metadata and `CHANGELOG.md`.
+2. Run local quality gates: `make test`, `make coverage`, `make typecheck`, `make deprecationcheck`, `make build`.
+3. Trigger a manual `Publish` workflow run against `testpypi` for the target ref.
+4. Verify package pages and install commands from TestPyPI.
+5. Push the release tag to publish to PyPI.
+6. Confirm the docs site and PyPI pages point to the same versioned story.
+
+See the full checklist in the repository root:
+
+- [`RELEASING.md`](https://github.com/rahulrajaram/hulista/blob/master/RELEASING.md)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6,<2
+mkdocs-material>=9.5,<10
+pymdown-extensions>=10,<11

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,56 @@
+.hero {
+  padding: 1.5rem 0 2rem;
+}
+
+.hero-kicker {
+  margin: 0;
+  color: var(--md-primary-fg-color);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0.4rem 0 0.8rem;
+  max-width: 14ch;
+  line-height: 1.05;
+}
+
+.hero-copy {
+  max-width: 52rem;
+  font-size: 1.05rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 1.2rem;
+}
+
+.package-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.package-card {
+  display: block;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--md-default-fg-color) 14%, transparent);
+  border-radius: 0.8rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--md-primary-fg-color) 10%, white), transparent 55%),
+    var(--md-default-bg-color);
+  text-decoration: none;
+}
+
+.package-card strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.package-card span {
+  color: var(--md-default-fg-color--light);
+}

--- a/fp-combinators/pyproject.toml
+++ b/fp-combinators/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-combinators"
-version = "0.1.1"
+version = "0.1.0"
 description = "Lightweight functional programming combinators: pipe, compose, first_some"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/fp-combinators/pyproject.toml
+++ b/fp-combinators/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["functional-programming", "pipe", "composition", "result", "asyncio"
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/hulista/README.md
+++ b/hulista/README.md
@@ -2,7 +2,19 @@
 
 Functional, immutable, concurrent Python — all batteries included.
 
-This is the umbrella meta-package that installs all seven hulista libraries in one go:
+`hulista` is the umbrella package for the full hulista toolkit. One install gives you immutable data structures, sealed typing, runtime dispatch, actor-style concurrency, collect-all task groups, functional combinators, and record-update ergonomics.
+
+Documentation: <https://rahulrajaram.github.io/hulista/>
+
+## Why install the umbrella package?
+
+Install `hulista` when you want a coherent batteries-included stack instead of picking packages one by one. It is especially useful for:
+
+- event-driven or agent-style systems that combine immutable state with async orchestration
+- teams that want one dependency and one docs entry point
+- experimentation across the full package family before narrowing to individual packages
+
+This meta-package installs all seven hulista libraries in one go:
 
 | Package | Import | Description |
 |---|---|---|
@@ -16,8 +28,16 @@ This is the umbrella meta-package that installs all seven hulista libraries in o
 
 ## Install
 
-```
+Install the full toolkit:
+
+```bash
 pip install hulista
+```
+
+Or install a single building block, for example:
+
+```bash
+pip install persistent-collections
 ```
 
 ## Quick start
@@ -44,5 +64,27 @@ class KeyPress(Event): pass
 
 subs = hulista.sealed_subclasses(Event)  # {Click, KeyPress}
 ```
+
+## What you get
+
+- `PersistentMap` / `PersistentVector` for immutable application state with structural sharing
+- `pipe`, `async_pipe`, `Ok`, and `Err` for dataflow and typed error handling
+- `ActorSystem` for supervised async workers and message passing
+- `Dispatcher` for runtime-extensible type or predicate dispatch
+- `sealed` for exhaustiveness-friendly closed hierarchies
+- `CollectorTaskGroup` for collect-all structured concurrency
+- `updatable` and `with_update` for record-update syntax on frozen models
+
+## Source layout
+
+Each package lives in the monorepo with its own README, tests, and PyPI distribution:
+
+- [`asyncio-actors/`](https://github.com/rahulrajaram/hulista/tree/master/asyncio-actors)
+- [`fp-combinators/`](https://github.com/rahulrajaram/hulista/tree/master/fp-combinators)
+- [`live-dispatch/`](https://github.com/rahulrajaram/hulista/tree/master/live-dispatch)
+- [`persistent-collections/`](https://github.com/rahulrajaram/hulista/tree/master/persistent-collections)
+- [`sealed-typing/`](https://github.com/rahulrajaram/hulista/tree/master/sealed-typing)
+- [`taskgroup-collect/`](https://github.com/rahulrajaram/hulista/tree/master/taskgroup-collect)
+- [`with-update/`](https://github.com/rahulrajaram/hulista/tree/master/with-update)
 
 ## Requires Python 3.11+

--- a/hulista/hulista/__init__.py
+++ b/hulista/hulista/__init__.py
@@ -32,7 +32,7 @@ from taskgroup_collect import CollectorTaskGroup
 # Updatable records
 from with_update import updatable, with_update
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # persistent-collections

--- a/hulista/hulista/__init__.py
+++ b/hulista/hulista/__init__.py
@@ -32,7 +32,7 @@ from taskgroup_collect import CollectorTaskGroup
 # Updatable records
 from with_update import updatable, with_update
 
-__version__ = "0.1.1"
+__version__ = "0.1.0"
 
 __all__ = [
     # persistent-collections

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hulista"
-version = "0.1.1"
+version = "0.1.0"
 description = "Functional, immutable, concurrent Python — all batteries included"
 readme = "README.md"
 license = "MIT"
@@ -22,13 +22,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "asyncio-actors>=0.1.1",
-    "fp-combinators>=0.1.1",
-    "live-dispatch>=0.1.1",
-    "persistent-collections>=0.1.1",
-    "sealed-typing>=0.1.1",
-    "taskgroup-collect>=0.1.1",
-    "with-update>=0.1.1",
+    "asyncio-actors>=0.1.0",
+    "fp-combinators>=0.1.0",
+    "live-dispatch>=0.1.0",
+    "persistent-collections>=0.1.0",
+    "sealed-typing>=0.1.0",
+    "taskgroup-collect>=0.1.0",
+    "with-update>=0.1.0",
 ]
 
 [project.urls]

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,17 +22,18 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "asyncio-actors>=0.1.0",
-    "fp-combinators>=0.1.0",
-    "live-dispatch>=0.1.0",
-    "persistent-collections>=0.1.0",
-    "sealed-typing>=0.1.0",
-    "taskgroup-collect>=0.1.0",
-    "with-update>=0.1.0",
+    "asyncio-actors>=0.1.1",
+    "fp-combinators>=0.1.1",
+    "live-dispatch>=0.1.1",
+    "persistent-collections>=0.1.1",
+    "sealed-typing>=0.1.1",
+    "taskgroup-collect>=0.1.1",
+    "with-update>=0.1.1",
 ]
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/hulista/tests/test_umbrella.py
+++ b/hulista/tests/test_umbrella.py
@@ -8,7 +8,8 @@ Verifies:
 """
 from __future__ import annotations
 
-import asyncio
+from pathlib import Path
+import tomllib
 import pytest
 
 import hulista
@@ -20,8 +21,10 @@ import hulista
 
 
 def test_version_exists() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    project_version = tomllib.loads(pyproject.read_text())["project"]["version"]
     assert hasattr(hulista, "__version__")
-    assert hulista.__version__ == "0.1.0"
+    assert hulista.__version__ == project_version
 
 
 # ---------------------------------------------------------------------------

--- a/live-dispatch/pyproject.toml
+++ b/live-dispatch/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "live-dispatch"
-version = "0.1.1"
+version = "0.1.0"
 description = "Runtime-extensible dispatch with multiple dispatch, predicate dispatch, and versioning"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/live-dispatch/pyproject.toml
+++ b/live-dispatch/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,50 @@
+site_name: hulista
+site_description: Functional programming and structured-concurrency building blocks for Python
+site_url: https://rahulrajaram.github.io/hulista/
+repo_url: https://github.com/rahulrajaram/hulista
+repo_name: rahulrajaram/hulista
+edit_uri: edit/master/docs/
+strict: true
+
+theme:
+  name: material
+  logo: null
+  font:
+    text: IBM Plex Sans
+    code: IBM Plex Mono
+  palette:
+    scheme: default
+    primary: teal
+    accent: amber
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Package Guide: packages.md
+  - Releasing: releasing.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra_css:
+  - stylesheets/extra.css

--- a/persistent-collections/pyproject.toml
+++ b/persistent-collections/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/persistent-collections/pyproject.toml
+++ b/persistent-collections/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "persistent-collections"
-version = "0.1.1"
+version = "0.1.0"
 description = "Immutable persistent collections with structural sharing (HAMT-based)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/write_security_requirements.py
+++ b/scripts/write_security_requirements.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Write the dependency set audited by ``make security``."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECTS = sorted(ROOT.glob("*/pyproject.toml"))
+DOCS_REQUIREMENTS = ROOT / "docs" / "requirements.txt"
+EXTRA_RELEASE_TOOLS = ("twine", "pkginfo")
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower().replace("_", "-").replace(".", "-")
+
+
+def _requirement_name(requirement: str) -> str:
+    token = requirement.strip()
+    end = len(token)
+    for marker in ("[", "<", ">", "=", "!", "~", ";", " "):
+        pos = token.find(marker)
+        if pos != -1:
+            end = min(end, pos)
+    return _normalize_name(token[:end])
+
+
+def _collect_internal_projects() -> set[str]:
+    names: set[str] = set()
+    for pyproject in PYPROJECTS:
+        data = tomllib.loads(pyproject.read_text())
+        project = data.get("project", {})
+        name = project.get("name")
+        if isinstance(name, str):
+            names.add(_normalize_name(name))
+    return names
+
+
+def _iter_declared_requirements() -> list[str]:
+    requirements: list[str] = []
+    for pyproject in PYPROJECTS:
+        data = tomllib.loads(pyproject.read_text())
+        project = data.get("project", {})
+        requirements.extend(project.get("dependencies", []))
+        optional = project.get("optional-dependencies", {})
+        for values in optional.values():
+            requirements.extend(values)
+    if DOCS_REQUIREMENTS.exists():
+        for line in DOCS_REQUIREMENTS.read_text().splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                requirements.append(stripped)
+    requirements.extend(EXTRA_RELEASE_TOOLS)
+    return requirements
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: write_security_requirements.py OUTPUT_PATH", file=sys.stderr)
+        return 2
+
+    output_path = Path(sys.argv[1])
+    internal_projects = _collect_internal_projects()
+    requirements = sorted(
+        {
+            requirement
+            for requirement in _iter_declared_requirements()
+            if _requirement_name(requirement) not in internal_projects
+        }
+    )
+    output_path.write_text("".join(f"{requirement}\n" for requirement in requirements))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sealed-typing/pyproject.toml
+++ b/sealed-typing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sealed-typing"
-version = "0.1.1"
+version = "0.1.0"
 description = "Sealed classes for Python with runtime enforcement and exhaustive matching support"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sealed-typing/pyproject.toml
+++ b/sealed-typing/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/taskgroup-collect/pyproject.toml
+++ b/taskgroup-collect/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["asyncio", "taskgroup", "structured-concurrency", "exceptiongroup", 
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/taskgroup-collect/pyproject.toml
+++ b/taskgroup-collect/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "taskgroup-collect"
-version = "0.1.1"
+version = "0.1.0"
 description = "TaskGroup variant that collects all errors instead of aborting on the first"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/taskgroup-collect/taskgroup_collect/_collector.py
+++ b/taskgroup-collect/taskgroup_collect/_collector.py
@@ -144,7 +144,8 @@ class CollectorTaskGroup:
                     self._abort()
             self._on_completed_fut = None
 
-        assert not self._tasks
+        if self._tasks:
+            raise RuntimeError("CollectorTaskGroup failed to drain all tasks before exit")
 
         # Build the outcomes list in creation order before clearing state.
         self._outcomes_result = []

--- a/with-update/pyproject.toml
+++ b/with-update/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "with-update"
-version = "0.1.1"
+version = "0.1.0"
 description = "Record update syntax for frozen dataclasses and Pydantic models via | operator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/with-update/pyproject.toml
+++ b/with-update/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["dataclasses", "pydantic", "record-update", "immutable", "validation
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
+Documentation = "https://rahulrajaram.github.io/hulista/"
 Repository = "https://github.com/rahulrajaram/hulista"
 "Bug Tracker" = "https://github.com/rahulrajaram/hulista/issues"
 Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"

--- a/with-update/with_update/_core.py
+++ b/with-update/with_update/_core.py
@@ -223,7 +223,8 @@ def _assoc_in(root: Any, path: Sequence[str], value: Any) -> Any:
     All intermediate nodes must be PersistentMap instances.
     """
     _require_persistent_collections("update_in")
-    assert _PersistentMap is not None  # guaranteed by _require_persistent_collections
+    if _PersistentMap is None:
+        raise RuntimeError("persistent-collections was required but is unavailable")
 
     if not path:
         return value


### PR DESCRIPTION
## Summary
- add a GitHub Pages docs site and release runbook for the public hulista release
- tighten package metadata and README/Documentation links for the umbrella package family
- remove runtime annotation eval, add security auditing, and enforce Bandit plus pip-audit in CI

## Validation
- make docs-build
- make security
- PYTHONPATH=... python -m pytest asyncio-actors/tests/test_dispatch_actor.py taskgroup-collect/tests with-update/tests hulista/tests/test_umbrella.py -q

## Versioning
- checked PyPI and none of the hulista packages are published yet, so no version bump was needed for this PR