### PR TITLE
feat(release): publish hulista as a single package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,31 +24,11 @@ permissions:
 
 jobs:
   publish:
-    name: Publish ${{ matrix.project }} to ${{ github.event_name == 'workflow_dispatch' && inputs.repository || 'pypi' }}
+    name: Publish hulista to ${{ github.event_name == 'workflow_dispatch' && inputs.repository || 'pypi' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - package-dir: asyncio-actors
-            project: asyncio-actors
-          - package-dir: fp-combinators
-            project: fp-combinators
-          - package-dir: live-dispatch
-            project: live-dispatch
-          - package-dir: persistent-collections
-            project: persistent-collections
-          - package-dir: sealed-typing
-            project: sealed-typing
-          - package-dir: taskgroup-collect
-            project: taskgroup-collect
-          - package-dir: with-update
-            project: with-update
-          - package-dir: hulista
-            project: hulista
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && inputs.repository || 'pypi' }}
-      url: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi') && format('https://test.pypi.org/project/{0}/', matrix.project) || format('https://pypi.org/project/{0}/', matrix.project) }}
+      url: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi') && 'https://test.pypi.org/project/hulista/' || 'https://pypi.org/project/hulista/' }}
     permissions:
       contents: read
       id-token: write
@@ -70,20 +50,20 @@ jobs:
         run: uv pip install --system --upgrade build twine pkginfo
 
       - name: Build distributions
-        run: cd ${{ matrix.package-dir }} && python -m build .
+        run: python scripts/build_hulista_dist.py
 
       - name: Verify distribution metadata
-        run: python -m twine check ${{ matrix.package-dir }}/dist/*
+        run: python -m twine check hulista/dist/*
 
       - name: Publish package distributions to PyPI
         if: github.event_name != 'workflow_dispatch' || inputs.repository == 'pypi'
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          packages-dir: ${{ matrix.package-dir }}/dist
+          packages-dir: hulista/dist
 
       - name: Publish package distributions to TestPyPI
         if: github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi'
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          packages-dir: ${{ matrix.package-dir }}/dist
+          packages-dir: hulista/dist
           repository-url: https://test.pypi.org/legacy/

--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,21 @@ bench:
 
 build:
 	for pkg in $(BUILD_PACKAGES); do \
-		(cd $$pkg && $(PYTHON) -m build .); \
+		if [ "$$pkg" = "hulista" ]; then \
+			$(PYTHON) scripts/build_hulista_dist.py; \
+		else \
+			(cd $$pkg && $(PYTHON) -m build .); \
+		fi; \
 	done
 
 deprecationcheck:
 	PYTHONPATH="$(PYTHONPATH)" $(PYTHON) $(PYTEST_DEPRECATION_FLAGS) -m pytest -p no:pytest_monitor $(PACKAGE_TESTS) -q
 	for pkg in $(BUILD_PACKAGES); do \
-		(cd $$pkg && $(PYTHON) $(BUILD_DEPRECATION_FLAGS) -m build .); \
+		if [ "$$pkg" = "hulista" ]; then \
+			PYTHONWARNINGS="error::DeprecationWarning,error::PendingDeprecationWarning,error::UserWarning:setuptools" $(PYTHON) scripts/build_hulista_dist.py; \
+		else \
+			(cd $$pkg && $(PYTHON) $(BUILD_DEPRECATION_FLAGS) -m build .); \
+		fi; \
 	done
 
 security:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ This repository already has the two core automation pieces needed for a public r
 Before the first public release, confirm these settings in GitHub and PyPI:
 
 1. Enable GitHub Pages for this repository and allow GitHub Actions to deploy it.
-2. Create `hulista` and each leaf package on PyPI and TestPyPI if you want to reserve the names ahead of time.
+2. Create the `hulista` project on PyPI and TestPyPI if you want to reserve the name ahead of time.
 3. Configure PyPI Trusted Publishing for this repository and the `pypi` environment.
 4. Configure TestPyPI Trusted Publishing for this repository and the `testpypi` environment.
 5. Protect the `pypi` environment if you want a manual approval gate before production publishing.
@@ -41,8 +41,8 @@ make build
 
 ```bash
 python -m pip install -U build twine pkginfo
+python scripts/build_hulista_dist.py
 cd hulista
-python -m build .
 python -m twine check dist/*
 ```
 
@@ -54,7 +54,7 @@ Use the existing `Publish` workflow before the first real release and before any
 2. Run `Publish`.
 3. Choose `repository = testpypi`.
 4. Set `ref` to the branch, commit SHA, or release candidate tag you want to validate.
-5. Wait for all matrix jobs to finish.
+5. Wait for the publish job to finish.
 
 Then validate installs from TestPyPI in a clean virtual environment. Example:
 
@@ -68,22 +68,22 @@ python -c "import hulista; print(hulista.__version__)"
 
 ## Production release
 
-The production path is tag-driven. Pushing a tag that matches `v*` will publish every package in the monorepo.
+The production path is tag-driven. Pushing a tag that matches `v*` will publish the `hulista` distribution.
 
 Recommended sequence:
 
 1. Merge the release commit to `master`.
 2. Create an annotated tag such as `v0.1.0`.
 3. Push the tag.
-4. Watch [`.github/workflows/publish.yml`](.github/workflows/publish.yml) complete for every package.
+4. Watch [`.github/workflows/publish.yml`](.github/workflows/publish.yml) complete for `hulista`.
 5. Verify the live pages on PyPI and the docs site.
 
 ## Release model
 
-This repo is currently set up for coordinated releases:
+This repo is currently released as a single public distribution:
 
 - one changelog
 - one release tag namespace
-- one publish workflow matrix for all packages
+- one PyPI project: `hulista`
 
-That is a good fit while the package family is still moving together. If you later want independent release cadences, the publish workflow and tag strategy should be split per package.
+The monorepo package directories remain useful for development, testing, and source organization, but only `hulista` is published.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,10 +8,11 @@ Use the umbrella package when you want the full stack:
 pip install hulista
 ```
 
-Use individual packages when you only need a subset:
+The single public distribution still exposes focused module imports when you only need a subset:
 
-```bash
-pip install persistent-collections live-dispatch
+```python
+from persistent_collections import PersistentMap
+from live_dispatch import Dispatcher
 ```
 
 ## What `hulista` re-exports
@@ -44,15 +45,15 @@ value = hulista.pipe(
 assert value == 20
 ```
 
-## When to pick individual packages
+## When to use focused imports
 
-Choose a focused package instead of `hulista` if:
+Choose focused imports instead of the `hulista` namespace if:
 
-- your library only needs one concept and you want minimal dependency surface
-- you need Python 3.10 support for a package that does not require 3.11
+- your library only uses one concept and you want your imports to stay explicit
+- you prefer importing `persistent_collections`, `live_dispatch`, or `with_update` directly in application code
 - you want to keep your public API explicit about which hulista primitive you depend on
 
-The umbrella package itself requires Python 3.11 because some bundled packages do.
+The `hulista` distribution itself requires Python 3.11 because some bundled modules do.
 
 ## Local docs workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,10 +30,12 @@ Install the umbrella package:
 pip install hulista
 ```
 
-Or install only the pieces you need:
+The single `hulista` distribution still lets you import only the pieces you need:
 
-```bash
-pip install persistent-collections sealed-typing taskgroup-collect
+```python
+from persistent_collections import PersistentMap
+from sealed_typing import sealed
+from taskgroup_collect import CollectorTaskGroup
 ```
 
 ## Quick example

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -102,6 +102,6 @@ Key APIs:
 - `with_update()`
 - `|`
 
-## Choosing the umbrella package
+## Choosing hulista
 
-Install `hulista` when you want one dependency and one docs entry point. Install individual packages when you want finer Python-version control or a narrower transitive dependency surface.
+Install `hulista` when you want one dependency and one docs entry point. The bundled modules are still importable directly, but the public PyPI package is `hulista`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,11 +15,11 @@ make docs-build
 
 ## Package publishing
 
-The PyPI workflow publishes every package in the monorepo, including `hulista`.
+The PyPI workflow publishes the `hulista` distribution only.
 
 Important implication:
 
-- A release tag is a coordinated monorepo release, not a one-package release.
+- A release tag publishes the bundled `hulista` wheel, which contains the toolkit modules from this monorepo.
 
 ## Recommended release flow
 

--- a/hulista/README.md
+++ b/hulista/README.md
@@ -2,7 +2,7 @@
 
 Functional, immutable, concurrent Python — all batteries included.
 
-`hulista` is the umbrella package for the full hulista toolkit. One install gives you immutable data structures, sealed typing, runtime dispatch, actor-style concurrency, collect-all task groups, functional combinators, and record-update ergonomics.
+`hulista` is the single published distribution for the full hulista toolkit. One install gives you immutable data structures, sealed typing, runtime dispatch, actor-style concurrency, collect-all task groups, functional combinators, and record-update ergonomics.
 
 Documentation: <https://rahulrajaram.github.io/hulista/>
 
@@ -12,9 +12,9 @@ Install `hulista` when you want a coherent batteries-included stack instead of p
 
 - event-driven or agent-style systems that combine immutable state with async orchestration
 - teams that want one dependency and one docs entry point
-- experimentation across the full package family before narrowing to individual packages
+- experimentation across the full package family before narrowing to individual imports
 
-This meta-package installs all seven hulista libraries in one go:
+The `hulista` wheel bundles the toolkit's runtime modules directly:
 
 | Package | Import | Description |
 |---|---|---|
@@ -34,10 +34,11 @@ Install the full toolkit:
 pip install hulista
 ```
 
-Or install a single building block, for example:
+The bundled modules remain importable directly if you prefer focused imports:
 
-```bash
-pip install persistent-collections
+```python
+from persistent_collections import PersistentMap
+from fp_combinators import pipe
 ```
 
 ## Quick start
@@ -77,7 +78,7 @@ subs = hulista.sealed_subclasses(Event)  # {Click, KeyPress}
 
 ## Source layout
 
-Each package lives in the monorepo with its own README, tests, and PyPI distribution:
+Each package lives in the monorepo with its own README and tests, but the public PyPI release is `hulista`:
 
 - [`asyncio-actors/`](https://github.com/rahulrajaram/hulista/tree/master/asyncio-actors)
 - [`fp-combinators/`](https://github.com/rahulrajaram/hulista/tree/master/fp-combinators)

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=77", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.10"]
+build-backend = "hatchling.build"
 
 [project]
 name = "hulista"
@@ -21,15 +21,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = [
-    "asyncio-actors>=0.1.0",
-    "fp-combinators>=0.1.0",
-    "live-dispatch>=0.1.0",
-    "persistent-collections>=0.1.0",
-    "sealed-typing>=0.1.0",
-    "taskgroup-collect>=0.1.0",
-    "with-update>=0.1.0",
-]
 
 [project.urls]
 Homepage = "https://github.com/rahulrajaram/hulista"
@@ -40,13 +31,37 @@ Changelog = "https://github.com/rahulrajaram/hulista/blob/master/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=9.0", "pytest-asyncio>=0.23", "pytest-cov>=5.0", "mypy>=1.19", "build>=1.3"]
+pydantic = ["pydantic>=2.0"]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["hulista*"]
+[tool.hatch.build.targets.wheel]
+packages = ["hulista/hulista"]
+only-packages = true
 
-[tool.setuptools.package-data]
-hulista = ["py.typed"]
+[tool.hatch.build.targets.wheel.force-include]
+"../asyncio-actors/asyncio_actors" = "asyncio_actors"
+"../fp-combinators/fp_combinators" = "fp_combinators"
+"../live-dispatch/live_dispatch" = "live_dispatch"
+"../persistent-collections/persistent_collections" = "persistent_collections"
+"../sealed-typing/sealed_typing" = "sealed_typing"
+"../taskgroup-collect/taskgroup_collect" = "taskgroup_collect"
+"../with-update/with_update" = "with_update"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "hulista",
+    "tests",
+    "README.md",
+    "pyproject.toml",
+]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../asyncio-actors/asyncio_actors" = "asyncio_actors"
+"../fp-combinators/fp_combinators" = "fp_combinators"
+"../live-dispatch/live_dispatch" = "live_dispatch"
+"../persistent-collections/persistent_collections" = "persistent_collections"
+"../sealed-typing/sealed_typing" = "sealed_typing"
+"../taskgroup-collect/taskgroup_collect" = "taskgroup_collect"
+"../with-update/with_update" = "with_update"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/hulista/tests/conftest.py
+++ b/hulista/tests/conftest.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PACKAGE_NAMES = (
+    "asyncio_actors",
+    "fp_combinators",
+    "live_dispatch",
+    "persistent_collections",
+    "sealed_typing",
+    "taskgroup_collect",
+    "with_update",
+)
+
+MONOREPO_PACKAGE_ROOTS = (
+    "asyncio-actors",
+    "fp-combinators",
+    "live-dispatch",
+    "persistent-collections",
+    "sealed-typing",
+    "taskgroup-collect",
+    "with-update",
+    "hulista",
+)
+
+
+def _project_roots() -> tuple[Path, ...]:
+    here = Path(__file__).resolve()
+    return (here.parents[1], here.parents[2])
+
+
+def _all_packages_present(root: Path) -> bool:
+    return all((root / name).is_dir() for name in PACKAGE_NAMES)
+
+
+def _configure_import_path() -> None:
+    for root in _project_roots():
+        if _all_packages_present(root):
+            sys.path.insert(0, str(root))
+            return
+
+        monorepo_paths = [root / package_root for package_root in MONOREPO_PACKAGE_ROOTS]
+        if all(path.is_dir() for path in monorepo_paths):
+            for path in reversed(monorepo_paths):
+                sys.path.insert(0, str(path))
+            return
+
+
+_configure_import_path()

--- a/hulista/tests/test_umbrella.py
+++ b/hulista/tests/test_umbrella.py
@@ -27,6 +27,22 @@ def test_version_exists() -> None:
     assert hulista.__version__ == project_version
 
 
+def test_no_internal_distribution_dependencies() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    project = tomllib.loads(pyproject.read_text())["project"]
+    dependencies = set(project.get("dependencies", []))
+    internal = {
+        "asyncio-actors>=0.1.0",
+        "fp-combinators>=0.1.0",
+        "live-dispatch>=0.1.0",
+        "persistent-collections>=0.1.0",
+        "sealed-typing>=0.1.0",
+        "taskgroup-collect>=0.1.0",
+        "with-update>=0.1.0",
+    }
+    assert dependencies.isdisjoint(internal)
+
+
 # ---------------------------------------------------------------------------
 # 2. All expected names are present in hulista namespace
 # ---------------------------------------------------------------------------

--- a/scripts/build_hulista_dist.py
+++ b/scripts/build_hulista_dist.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HULISTA_DIR = ROOT / "hulista"
+GENERATED_PATHS = [
+    HULISTA_DIR / "asyncio-actors",
+    HULISTA_DIR / "fp-combinators",
+    HULISTA_DIR / "live-dispatch",
+    HULISTA_DIR / "persistent-collections",
+    HULISTA_DIR / "sealed-typing",
+    HULISTA_DIR / "taskgroup-collect",
+    HULISTA_DIR / "with-update",
+    HULISTA_DIR / "hulista" / "hulista",
+    HULISTA_DIR / "hulista" / "tests",
+]
+
+
+def _cleanup_generated_paths() -> None:
+    for path in GENERATED_PATHS:
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def _run_build(*args: str) -> None:
+    subprocess.run(
+        [sys.executable, "-m", "build", *args, "."],
+        cwd=HULISTA_DIR,
+        check=True,
+    )
+
+
+def main() -> int:
+    _cleanup_generated_paths()
+    try:
+        _run_build("--sdist")
+        _run_build("--wheel")
+    finally:
+        _cleanup_generated_paths()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- publish only the `hulista` distribution from GitHub Actions
- bundle the sibling runtime modules into the single `hulista` artifact
- update docs, release notes, and tests to reflect the single-package release model

## Validation
- make build
- cd hulista && python -m twine check dist/*
- python -m pytest hulista/tests/test_umbrella.py -q
- make docs-build
- make typecheck
- make deprecationcheck