### PR TITLE
ci(docs): auto-enable GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Build docs site
         run: python -m mkdocs build --strict


### PR DESCRIPTION
## Summary
- set `actions/configure-pages` to `enablement: true`
- let the docs workflow bootstrap Pages on first run instead of failing with a missing site 404

## Context
The docs workflow currently fails before deploy with `Get Pages site failed` when Pages has not been enabled yet in repository settings.

## Validation
- make docs-build