### PR TITLE
fix(release): ship top-level hulista package in wheel (0.1.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Verify distribution metadata
         run: python -m twine check hulista/dist/*
 
+      - name: Smoke-test built wheel in a clean venv
+        run: |
+          uv venv /tmp/hulista-smoke --python 3.11
+          uv pip install --python /tmp/hulista-smoke/bin/python hulista/dist/hulista-*.whl
+          /tmp/hulista-smoke/bin/python -c "from hulista import Result, Ok, Err, PersistentMap, PersistentVector, sealed, Dispatcher, CollectorTaskGroup, updatable, with_update, Actor; import hulista; print('hulista', hulista.__version__)"
+
       - name: Publish package distributions to PyPI
         if: github.event_name != 'workflow_dispatch' || inputs.repository == 'pypi'
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.1 - 2026-04-19
+
+### Fixed
+
+- `hulista`: wheel now ships the top-level `hulista` package. In 0.1.0 a misconfigured `[tool.hatch.build.targets.wheel]` `packages` path caused Hatch to silently skip the meta-package, so `from hulista import Result, PersistentMap, sealed, ...` (the documented primary API) raised `ModuleNotFoundError` on every fresh install. Editable installs masked the bug, so it reached PyPI. Reported by the `selfimprove` agent via gptqueue.
+
+### Added
+
+- CI: release workflow now installs the built wheel into a clean venv and imports the top-level `hulista` API as a smoke test, so a broken meta-package wheel cannot reach PyPI again.
+
 ## 0.1.0 - 2026-04-05
 
 Initial monorepo release for the hulista package family.

--- a/hulista/hulista/__init__.py
+++ b/hulista/hulista/__init__.py
@@ -32,7 +32,7 @@ from taskgroup_collect import CollectorTaskGroup
 # Updatable records
 from with_update import updatable, with_update
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # persistent-collections

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hulista"
-version = "0.1.0"
+version = "0.1.1"
 description = "Functional, immutable, concurrent Python — all batteries included"
 readme = "README.md"
 license = "MIT"
@@ -34,7 +34,7 @@ dev = ["pytest>=9.0", "pytest-asyncio>=0.23", "pytest-cov>=5.0", "mypy>=1.19", "
 pydantic = ["pydantic>=2.0"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["hulista/hulista"]
+packages = ["hulista"]
 only-packages = true
 
 [tool.hatch.build.targets.wheel.force-include]


### PR DESCRIPTION
## Summary

- 0.1.0 wheel on PyPI was missing the top-level `hulista/` package because `[tool.hatch.build.targets.wheel] packages = ["hulista/hulista"]` resolved to a nonexistent path; Hatch silently skipped it, so the documented primary API (`from hulista import Result, PersistentMap, sealed, ...`) raised `ModuleNotFoundError` on every fresh install. Editable installs masked the bug in the monorepo.
- Fix: `packages = ["hulista"]`, version bump to 0.1.1, CHANGELOG entry crediting the `selfimprove` agent.
- New release-time smoke test in `publish.yml` installs the built wheel into a clean venv and imports the full top-level API before uploading to PyPI, so a broken meta-package wheel cannot reach PyPI again.

## Test plan

- [x] Rebuild wheel locally: `hulista/` now present as a top-level directory in the archive.
- [x] Fresh-venv install of `hulista-0.1.1-py3-none-any.whl` and import all re-exports (`Result`, `PersistentMap`, `sealed`, `Dispatcher`, `CollectorTaskGroup`, `updatable`, `Actor`, etc.) → works, reports `hulista 0.1.1`.
- [ ] CI on this PR (tests workflow) passes.
- [ ] After merge: tag `v0.1.1` to trigger the publish workflow; the new smoke-test step runs before the PyPI upload.