### PR TITLE
chore(release): 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.2 - 2026-04-25
+
+### Fixed
+
+- `persistent-collections`: ship `persistent_set.pyi` so `PersistentSet[T]` annotations stop tripping Pyright's `reportInvalidTypeArguments`. The runtime class shipped in 0.1.1 but no type stub, so downstream typed projects had to suppress the diagnostic per call site or drop typing. Stub mirrors the existing `persistent_vector.pyi` shape (`Generic[T] + collections.abc.Set[T]`, `iterable: object | None = ...`).
+
 ## 0.1.1 - 2026-04-19
 
 ### Fixed

--- a/hulista/hulista/__init__.py
+++ b/hulista/hulista/__init__.py
@@ -32,7 +32,7 @@ from taskgroup_collect import CollectorTaskGroup
 # Updatable records
 from with_update import updatable, with_update
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     # persistent-collections

--- a/hulista/pyproject.toml
+++ b/hulista/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hulista"
-version = "0.1.1"
+version = "0.1.2"
 description = "Functional, immutable, concurrent Python — all batteries included"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Ships the `persistent_set.pyi` stub from #53 to PyPI consumers. Pure type-stub release — no runtime change.

- `hulista/pyproject.toml`: `0.1.1` → `0.1.2`
- `hulista/hulista/__init__.py`: `__version__` `0.1.1` → `0.1.2`
- `CHANGELOG.md`: 0.1.2 entry under **Fixed**

## Test plan

- [x] `make typecheck` — both strict gates green (40 + 63 source files).
- [x] `make build` — produces `hulista-0.1.2-py3-none-any.whl` + `hulista-0.1.2.tar.gz`.
- [x] Wheel inspection confirms top-level `hulista/` package present (regression check from the 0.1.0/0.1.1 incident) **and** the new `persistent_set.pyi` is shipped.
- [ ] CI green on this PR.
- [ ] After merge, push tag `v0.1.2` to trigger `.github/workflows/publish.yml` → PyPI publish.